### PR TITLE
Update mod.rs

### DIFF
--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -44,6 +44,7 @@ impl BatteryReadout for NetBSDBatteryReadout {
                             .get(1)
                             .map_or("", |m| m.as_str())
                             .to_string()
+                            .replace(" ","")
                             .replace("%", "");
                         let percentage_f = percentage.parse::<f32>().unwrap();
                         let percentage_i = percentage_f.round() as u8;


### PR DESCRIPTION
/usr/sbin/envstat, at least under -current 9.99.81, inserts a space before the percent charge when the values for this are low; I haven't tested all possible combinations, but on my old laptop with a battery almost non-functional I get
  charge:     0.000                      3.571%   1.786%   Ah ( 0.00%) 

The space before 0.00% causes trouble with the conversion.