### PR TITLE
Patch to add support for Flatpak (Linux Only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ itertools = "0.10.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sqlite = "0.26.0"
+home = "0.5.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.1"

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,10 +1,10 @@
 use crate::extra;
 use crate::traits::*;
 use itertools::Itertools;
+use std::fs;
 use std::fs::read_dir;
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::{fs, path::PathBuf};
 use sysctl::{Ctl, Sysctl};
 
 impl From<sqlite::Error> for ReadoutError {
@@ -474,6 +474,7 @@ impl LinuxPackageReadout {
     /// that have `flatpak` instaleld.
     fn count_flatpak() -> Option<usize> {
         use home;
+        use std::path::PathBuf;
 
         let global_flatpak_dir = Path::new("/var/lib/flatpak/app");
         let mut global_packages: usize = 0;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -436,6 +436,7 @@ pub enum PackageManager {
     Eopkg,
     Rpm,
     Cargo,
+    Flatpak,
 }
 
 impl ToString for PackageManager {
@@ -452,6 +453,7 @@ impl ToString for PackageManager {
             PackageManager::Eopkg => "eopkg",
             PackageManager::Rpm => "rpm",
             PackageManager::Cargo => "cargo",
+            PackageManager::Flatpak => "flatpak",
         })
     }
 }


### PR DESCRIPTION
- The way it counts package is by returning the number of entries in
  /var/lib/flatpak/app. This path is where system-wide flatpaks are
  installed meaning it currently doesn't count per-user
  packages, but this will be added in the next patch.