### PR TITLE
New functionality: CPU Usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ os-release = "0.1"
 core-foundation = "0.9.1"
 mach = "0.3.2"
 
+[target.'cfg(target_family = "unix")'.dependencies]
+num_cpus = "1.0"
+
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 sysctl = "0.4.0"
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -175,6 +175,14 @@ impl GeneralReadout for LinuxGeneralReadout {
         Ok(crate::shared::cpu_model_name())
     }
 
+    fn cpu_cores(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_cores()
+    }
+
+    fn cpu_usage(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_usage()
+    }
+
     fn uptime(&self) -> Result<usize, ReadoutError> {
         crate::shared::uptime()
     }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -265,6 +265,14 @@ impl GeneralReadout for MacOSGeneralReadout {
             .value_string()?)
     }
 
+    fn cpu_cores(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_cores()
+    }
+
+    fn cpu_usage(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_usage()
+    }
+
     fn uptime(&self) -> Result<usize, ReadoutError> {
         use libc::timeval;
         use std::time::{Duration, SystemTime, UNIX_EPOCH};

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -189,6 +189,14 @@ impl GeneralReadout for NetBSDGeneralReadout {
         Ok(crate::shared::cpu_model_name())
     }
 
+    fn cpu_cores(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_cores()
+    }
+
+    fn cpu_usage(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_usage()
+    }
+
     fn uptime(&self) -> Result<usize, ReadoutError> {
         crate::shared::uptime()
     }

--- a/src/openwrt/mod.rs
+++ b/src/openwrt/mod.rs
@@ -129,6 +129,14 @@ impl GeneralReadout for OpenWrtGeneralReadout {
         ))
     }
 
+    fn cpu_cores(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_cores()
+    }
+
+    fn cpu_usage(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_usage()
+    }
+
     fn uptime(&self) -> Result<usize, ReadoutError> {
         crate::shared::uptime()
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -437,6 +437,16 @@ pub trait GeneralReadout {
         Err(STANDARD_NO_IMPL.clone())
     }
 
+    /// This function should return the average CPU usage over the last minute.
+    fn cpu_usage(&self) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
+    /// This function should return the average CPU usage over the last minute.
+    fn cpu_cores(&self) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
     /// This function should return the uptime of the OS in seconds.
     fn uptime(&self) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())


### PR DESCRIPTION
- libmacchina can now provide the processor's usage/load over the last 1
  minute, in an OS-independent way.

- You might also notice that cpu_cores() is now a thing, thanks to the
  num_cpus crate, as its part of the equation when calculating CPU
  usage, this essentially means that libmacchina now handles this
  information, and Macchina doesn't have to query num_cpus directly.