### PR TITLE
Include a way to query logical CPU cores

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmacchina"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["grtcdr <ba.tahaaziz@gmail.com>", "Marvin Haschker <marvin@haschker.me>"]
 edition = "2018"
 description = "Provides the fetching capabilities for Macchina."

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -175,6 +175,10 @@ impl GeneralReadout for LinuxGeneralReadout {
         Ok(crate::shared::cpu_model_name())
     }
 
+    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_physical_cores()
+    }
+
     fn cpu_cores(&self) -> Result<usize, ReadoutError> {
         crate::shared::cpu_cores()
     }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -269,6 +269,10 @@ impl GeneralReadout for MacOSGeneralReadout {
         crate::shared::cpu_cores()
     }
 
+    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_physical_cores()
+    }
+
     fn cpu_usage(&self) -> Result<usize, ReadoutError> {
         crate::shared::cpu_usage()
     }

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -193,6 +193,10 @@ impl GeneralReadout for NetBSDGeneralReadout {
         crate::shared::cpu_cores()
     }
 
+    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_physical_cores()
+    }
+
     fn cpu_usage(&self) -> Result<usize, ReadoutError> {
         crate::shared::cpu_usage()
     }

--- a/src/openwrt/mod.rs
+++ b/src/openwrt/mod.rs
@@ -133,6 +133,10 @@ impl GeneralReadout for OpenWrtGeneralReadout {
         crate::shared::cpu_cores()
     }
 
+    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
+        crate::shared::cpu_physical_cores()
+    }
+
     fn cpu_usage(&self) -> Result<usize, ReadoutError> {
         crate::shared::cpu_usage()
     }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -249,6 +249,11 @@ pub(crate) fn cpu_usage() -> Result<usize, ReadoutError> {
 
 #[cfg(target_family = "unix")]
 pub(crate) fn cpu_cores() -> Result<usize, ReadoutError> {
+    Ok(num_cpus::get())
+}
+
+#[cfg(target_family = "unix")]
+pub(crate) fn cpu_physical_cores() -> Result<usize, ReadoutError> {
     Ok(num_cpus::get_physical())
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -442,7 +442,12 @@ pub trait GeneralReadout {
         Err(STANDARD_NO_IMPL.clone())
     }
 
-    /// This function should return the number of cores of the host's processor.
+    /// This function should return the number of physical cores of the host's processor.
+    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
+    /// This function should return the number of logical cores of the host's processor.
     fn cpu_cores(&self) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }


### PR DESCRIPTION
This will allow Macchina to display logical CPU cores, just like always.