### PR TITLE
🚩 NetBSD: Terminal fetching without `ps`

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -6,8 +6,7 @@ use itertools::Itertools;
 use std::fs;
 use std::fs::read_dir;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use sysctl::{Ctl, Sysctl};
 use sysinfo_ffi::sysinfo;
@@ -175,21 +174,27 @@ impl GeneralReadout for LinuxGeneralReadout {
     }
 
     fn terminal(&self) -> Result<String, ReadoutError> {
+        // Fetching terminal information is a three step process:
+        // 1. Get the shell PID, i.e. the PPID of this program
+        // 2. Get the PPID of the shell, i.e. the controlling terminal
+        // 3. Get the command associated with the shell's PPID
+
+        // 1. Get the shell PID, i.e. the PPID of this program.
         // This function is always successful.
         fn get_shell_pid() -> i32 {
             let pid = unsafe { libc::getppid() };
             return pid;
         }
 
-        // Obtain the value of a specified field from a /proc/PID/status file
-        fn get_process_status_field(ppid: i32, value: &str) -> i32 {
+        // 2. Get the PPID of the shell, i.e. the cotrolling terminal.
+        fn get_shell_ppid(ppid: i32) -> i32 {
             let process_path = PathBuf::from("/proc").join(ppid.to_string()).join("status");
             let file = fs::File::open(process_path);
             match file {
                 Ok(content) => {
                     let reader = BufReader::new(content);
                     for line in reader.lines().flatten() {
-                        if line.to_uppercase().starts_with(value) {
+                        if line.to_uppercase().starts_with("PPID") {
                             let s_mem_kb: String =
                                 line.chars().filter(|c| c.is_digit(10)).collect();
                             return s_mem_kb.parse::<i32>().unwrap_or(-1);
@@ -201,9 +206,9 @@ impl GeneralReadout for LinuxGeneralReadout {
             }
         }
 
-        // Returns the name of the controlling terminal
+        // 3. Get the command associated with the shell's PPID.
         fn terminal_name() -> String {
-            let terminal_pid = get_process_status_field(get_shell_pid(), "PPID");
+            let terminal_pid = get_shell_ppid(get_shell_pid());
             if terminal_pid != -1 {
                 let path = PathBuf::from("/proc")
                     .join(terminal_pid.to_string())

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -192,24 +192,26 @@ impl GeneralReadout for LinuxGeneralReadout {
                         if line.to_uppercase().starts_with(value) {
                             let s_mem_kb: String =
                                 line.chars().filter(|c| c.is_digit(10)).collect();
-                            return s_mem_kb.parse::<i32>().unwrap_or(0);
+                            return s_mem_kb.parse::<i32>().unwrap_or(-1);
                         }
                     }
-                    0
+                    -1
                 }
-                Err(_e) => 0,
+                Err(_e) => -1,
             }
         }
 
         // Returns the name of the controlling terminal
         fn terminal_name() -> String {
             let terminal_pid = get_process_status_field(get_shell_pid(), "PPID");
-            let path = PathBuf::from("/proc")
-                .join(terminal_pid.to_string())
-                .join("comm");
+            if terminal_pid != -1 {
+                let path = PathBuf::from("/proc")
+                    .join(terminal_pid.to_string())
+                    .join("comm");
 
-            if let Ok(terminal_name) = fs::read_to_string(path) {
-                return terminal_name;
+                if let Ok(terminal_name) = fs::read_to_string(path) {
+                    return terminal_name;
+                }
             }
 
             String::new()

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -211,11 +211,7 @@ pub(crate) fn cpu_model_name() -> String {
     }
 }
 
-#[cfg(all(
-    target_family = "unix",
-    not(target_os = "android"),
-    not(target_os = "linux")
-))]
+#[cfg(all(target_os = "macos", target_os = "netbsd"))]
 pub(crate) fn cpu_usage() -> Result<usize, ReadoutError> {
     let nelem: i32 = 1;
     let mut value: f64 = 0.0;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -211,7 +211,7 @@ pub(crate) fn cpu_model_name() -> String {
     }
 }
 
-#[cfg(all(target_os = "macos", target_os = "netbsd"))]
+#[cfg(any(target_os = "macos", target_os = "netbsd"))]
 pub(crate) fn cpu_usage() -> Result<usize, ReadoutError> {
     let nelem: i32 = 1;
     let mut value: f64 = 0.0;


### PR DESCRIPTION
- Another small change was that I modified the return value to be -1 when
get_process_status_field() fails.

- get_process_status_field() was renamed to get_shell_ppid() as this
seems more appropriate for the job that it accomplishes.

- Another check has been added to ensure that in case of terminal fetching
failure, the program should not return an unexpected value: terminal_name() will
only continue if it receives a PID that is not -1.