### PR TITLE
🐛 Package manager bug fixes

### DIFF
--- a/src/extra.rs
+++ b/src/extra.rs
@@ -113,14 +113,13 @@ pub fn count_lines<T>(buffer: T) -> Option<usize>
 where
     T: std::string::ToString,
 {
-    Some(
-        pop_newline(buffer.to_string().trim())
-            .as_bytes()
-            .iter()
-            .filter(|&&c| c == b'\n')
-            .count()
-            + 1,
-    )
+    let buf = buffer.to_string().trim().to_owned();
+
+    if !buf.is_empty() {
+        return Some(buf.as_bytes().iter().filter(|&&c| c == b'\n').count() + 1);
+    }
+
+    None
 }
 
 /**

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -1,6 +1,7 @@
 //! This module provides additional functionalities
 
 use std::env;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 /**
@@ -137,6 +138,11 @@ pub fn list_dir_entries(path: &Path) -> Vec<PathBuf> {
         }
     }
     directory_entries
+}
+
+/// Returns
+pub fn path_extension(path: &Path) -> Option<&str> {
+    path.extension().and_then(OsStr::to_str)
 }
 
 #[cfg(test)]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -501,7 +501,14 @@ impl LinuxPackageReadout {
             return Some(
                 dir_entries
                     .iter()
-                    .filter(|x| x.ends_with(".list"))
+                    .filter(|x| {
+                        if let Some(ext) = extra::path_extension(x) {
+                            if ext == ".list" {
+                                return true;
+                            }
+                        }
+                        return false;
+                    })
                     .into_iter()
                     .count(),
             );
@@ -606,10 +613,12 @@ impl LinuxPackageReadout {
                     dir_entries
                         .iter()
                         .filter(|x| {
-                            if x.is_file() && x.ends_with(".snap") {
-                                return true;
+                            if let Some(ext) = extra::path_extension(x) {
+                                if ext == ".snap" {
+                                    return true;
+                                }
                             }
-                            false
+                            return false;
                         })
                         .into_iter()
                         .count(),

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -6,8 +6,7 @@ use itertools::Itertools;
 use std::fs;
 use std::fs::read_dir;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use sysctl::{Ctl, Sysctl};
 use sysinfo_ffi::sysinfo;
@@ -175,21 +174,27 @@ impl GeneralReadout for LinuxGeneralReadout {
     }
 
     fn terminal(&self) -> Result<String, ReadoutError> {
+        // Fetching terminal information is a three step process:
+        // 1. Get the shell PID, i.e. the PPID of this program
+        // 2. Get the PPID of the shell, i.e. the controlling terminal
+        // 3. Get the command associated with the shell's PPID
+
+        // 1. Get the shell PID, i.e. the PPID of this program.
         // This function is always successful.
         fn get_shell_pid() -> i32 {
             let pid = unsafe { libc::getppid() };
             return pid;
         }
 
-        // Obtain the value of a specified field from a /proc/PID/status file
-        fn get_process_status_field(ppid: i32, value: &str) -> i32 {
+        // 2. Get the PPID of the shell, i.e. the cotrolling terminal.
+        fn get_shell_ppid(ppid: i32) -> i32 {
             let process_path = PathBuf::from("/proc").join(ppid.to_string()).join("status");
             let file = fs::File::open(process_path);
             match file {
                 Ok(content) => {
                     let reader = BufReader::new(content);
                     for line in reader.lines().flatten() {
-                        if line.to_uppercase().starts_with(value) {
+                        if line.to_uppercase().starts_with("PPID") {
                             let s_mem_kb: String =
                                 line.chars().filter(|c| c.is_digit(10)).collect();
                             return s_mem_kb.parse::<i32>().unwrap_or(-1);
@@ -201,9 +206,9 @@ impl GeneralReadout for LinuxGeneralReadout {
             }
         }
 
-        // Returns the name of the controlling terminal
+        // 3. Get the command associated with the shell's PPID.
         fn terminal_name() -> String {
-            let terminal_pid = get_process_status_field(get_shell_pid(), "PPID");
+            let terminal_pid = get_shell_ppid(get_shell_pid());
             if terminal_pid != -1 {
                 let path = PathBuf::from("/proc")
                     .join(terminal_pid.to_string())

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -192,24 +192,26 @@ impl GeneralReadout for LinuxGeneralReadout {
                         if line.to_uppercase().starts_with(value) {
                             let s_mem_kb: String =
                                 line.chars().filter(|c| c.is_digit(10)).collect();
-                            return s_mem_kb.parse::<i32>().unwrap_or(0);
+                            return s_mem_kb.parse::<i32>().unwrap_or(-1);
                         }
                     }
-                    0
+                    -1
                 }
-                Err(_e) => 0,
+                Err(_e) => -1,
             }
         }
 
         // Returns the name of the controlling terminal
         fn terminal_name() -> String {
             let terminal_pid = get_process_status_field(get_shell_pid(), "PPID");
-            let path = PathBuf::from("/proc")
-                .join(terminal_pid.to_string())
-                .join("comm");
+            if terminal_pid != -1 {
+                let path = PathBuf::from("/proc")
+                    .join(terminal_pid.to_string())
+                    .join("comm");
 
-            if let Ok(terminal_name) = fs::read_to_string(path) {
-                return terminal_name;
+                if let Ok(terminal_name) = fs::read_to_string(path) {
+                    return terminal_name;
+                }
             }
 
             String::new()

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -211,11 +211,7 @@ pub(crate) fn cpu_model_name() -> String {
     }
 }
 
-#[cfg(all(
-    target_family = "unix",
-    not(target_os = "android"),
-    not(target_os = "linux")
-))]
+#[cfg(all(target_os = "macos", target_os = "netbsd"))]
 pub(crate) fn cpu_usage() -> Result<usize, ReadoutError> {
     let nelem: i32 = 1;
     let mut value: f64 = 0.0;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -211,7 +211,7 @@ pub(crate) fn cpu_model_name() -> String {
     }
 }
 
-#[cfg(all(target_os = "macos", target_os = "netbsd"))]
+#[cfg(any(target_os = "macos", target_os = "netbsd"))]
 pub(crate) fn cpu_usage() -> Result<usize, ReadoutError> {
     let nelem: i32 = 1;
     let mut value: f64 = 0.0;


### PR DESCRIPTION
- All package managers should now return `None` when they fail to fetch.
- `snap` and `dpkg` now properly fetch package information.