### PR TITLE
Remove bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ libc = "0.2.88"
 local_ipaddress = "0.1.3"
 lazy_static = "1.4.0"
 
-[build-dependencies]
-bindgen = "0.58.1"
-
 [target.'cfg(target_os = "linux")'.dependencies]
 sqlite = "0.26.0"
 dirs = "3.0.2"

--- a/build.rs
+++ b/build.rs
@@ -13,25 +13,10 @@ fn build_macos() {
     println!("cargo:rustc-link-lib=framework=IOKit");
 }
 
-fn build_android() {
-    println!("cargo:rerun-if-changed=src/android/system_properties.h");
-    let bindings = bindgen::Builder::default()
-        .header("src/android/system_properties.h")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .generate()
-        .expect("Unable to generate bindings");
-
-    let out_path = std::path::PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("system_properties.rs"))
-        .expect("Couldn't write bindings!");
-}
-
 fn main() {
     match env::var("CARGO_CFG_TARGET_OS").as_ref().map(|x| &**x) {
         Ok("macos") => build_macos(),
         Ok("windows") => build_windows(),
-        Ok("android") => build_android(),
         _ => {}
     }
 }

--- a/src/android/system_properties.h
+++ b/src/android/system_properties.h
@@ -1,1 +1,0 @@
-#include <sys/system_properties.h>

--- a/src/android/system_properties.rs
+++ b/src/android/system_properties.rs
@@ -5,7 +5,12 @@
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
-include!(concat!(env!("OUT_DIR"), "/system_properties.rs"));
+extern "C" {
+    pub fn __system_property_get(
+        __name: *const ::std::os::raw::c_char,
+        __value: *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
 
 pub fn to_string_safe(param: *mut c_char) -> String {
     unsafe { CStr::from_ptr(param).to_string_lossy().into_owned() }


### PR DESCRIPTION
remove build_android()

Removing this improves the build time and doesn't include unnecessary code.