### PR TITLE
Resolution support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Macchina-CLI/libmacchina"
 readme = "README.md"
 license = "MIT"
 build = "build.rs"
+links = "X11"
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -45,6 +46,10 @@ itertools = "0.10.0"
 [target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))'.dependencies]
 sysctl = "0.4.1"
 
+[target.'cfg(any(target_os = "linux", target_os = "netbsd"))'.dependencies]
+x11="2.18.2"
+
 [features]
 openwrt = []
+xlib = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,4 @@ x11="2.18.2"
 
 [features]
 openwrt = []
-xlib = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmacchina"
-version = "0.4.6"
+version = "0.4.0"
 authors = ["grtcdr <ba.tahaaziz@gmail.com>", "Marvin Haschker <marvin@haschker.me>"]
 edition = "2018"
 description = "Provides the fetching capabilities for Macchina."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmacchina"
-version = "0.3.6"
+version = "0.4.6"
 authors = ["grtcdr <ba.tahaaziz@gmail.com>", "Marvin Haschker <marvin@haschker.me>"]
 edition = "2018"
 description = "Provides the fetching capabilities for Macchina."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/Macchina-CLI/libmacchina"
 readme = "README.md"
 license = "MIT"
 build = "build.rs"
-links = "X11"
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,10 @@ fn build_windows() {
     );
 }
 
+fn build_linux_netbsd() {
+    println!("cargo:rustc-link-lib=X11");
+}
+
 fn build_macos() {
     println!("cargo:rustc-link-lib=framework=Foundation");
     println!("cargo:rustc-link-lib=framework=IOKit");
@@ -17,6 +21,7 @@ fn main() {
     match env::var("CARGO_CFG_TARGET_OS").as_ref().map(|x| &**x) {
         Ok("macos") => build_macos(),
         Ok("windows") => build_windows(),
+        Ok("linux") | Ok("netbsd") => build_linux_netbsd(),
         _ => {}
     }
 }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -197,11 +197,13 @@ impl GeneralReadout for LinuxGeneralReadout {
                         let modes = std::path::PathBuf::from(entry).join("modes");
                         if modes.is_file() {
                             if let Ok(mut this_res) = std::fs::read_to_string(modes) {
-                                if this_res.ends_with("\n") {
-                                    this_res.pop();
+                                if this_res.is_empty() {
+                                    if this_res.ends_with("\n") {
+                                        this_res.pop();
+                                    }
+                                    resolution.push_str(&this_res);
+                                    resolution.push_str(", ");
                                 }
-                                resolution.push_str(&this_res);
-                                resolution.push_str(", ");
                             }
                         }
                     }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -140,6 +140,31 @@ impl GeneralReadout for LinuxGeneralReadout {
         }
     }
 
+    fn backlight(&self) -> Result<usize, ReadoutError> {
+        use std::path::Path;
+        let backlight_path = Path::new("/sys/class/backlight/").to_path_buf();
+
+        let max_brightness_path = backlight_path.join("max_brightness");
+
+        let current_brightness_path = backlight_path.join("brightness");
+
+        let max_brightness_value = extra::pop_newline(fs::read_to_string(max_brightness_path)?)
+            .parse::<u32>()
+            .ok();
+
+        let current_brightness_value =
+            extra::pop_newline(fs::read_to_string(current_brightness_path)?)
+                .parse::<u32>()
+                .ok();
+
+        match (current_brightness_value, max_brightness_value) {
+            (Some(c), Some(m)) => Ok(c as usize / m as usize * 100),
+            _ => Err(ReadoutError::Other(String::from(
+                "Could not read from intel_backlight/max_brightness or intel_backlight/brightness",
+            ))),
+        }
+    }
+
     fn machine(&self) -> Result<String, ReadoutError> {
         let product_readout = LinuxProductReadout::new();
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -165,6 +165,35 @@ impl GeneralReadout for LinuxGeneralReadout {
         }
     }
 
+    fn resolution(&self) -> Result<String, ReadoutError> {
+        use std::os::raw::*;
+        use x11::xlib::XCloseDisplay;
+        use x11::xlib::XDefaultScreen;
+        use x11::xlib::XDisplayHeight;
+        use x11::xlib::XDisplayWidth;
+        use x11::xlib::XOpenDisplay;
+        let display_name: *const c_char = std::ptr::null_mut();
+
+        let display = unsafe { XOpenDisplay(display_name) };
+        if !display.is_null() {
+            let screen = unsafe { XDefaultScreen(display) };
+            let width = unsafe { XDisplayWidth(display, screen) };
+            let height = unsafe { XDisplayHeight(display, screen) };
+
+            return Ok(format!("{}x{}", width, height));
+        }
+
+        unsafe { XCloseDisplay(display) };
+
+        unsafe {
+            libc::free(display_name as *mut libc::c_void);
+        }
+
+        Err(ReadoutError::Other(String::from(
+            "Could not obtain screen resolution.",
+        )))
+    }
+
     fn machine(&self) -> Result<String, ReadoutError> {
         let product_readout = LinuxProductReadout::new();
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -166,12 +166,13 @@ impl GeneralReadout for LinuxGeneralReadout {
     }
 
     fn resolution(&self) -> Result<String, ReadoutError> {
-        use std::os::raw::*;
+        use std::os::raw::c_char;
         use x11::xlib::XCloseDisplay;
         use x11::xlib::XDefaultScreen;
         use x11::xlib::XDisplayHeight;
         use x11::xlib::XDisplayWidth;
         use x11::xlib::XOpenDisplay;
+
         let display_name: *const c_char = std::ptr::null_mut();
 
         let display = unsafe { XOpenDisplay(display_name) };
@@ -180,13 +181,38 @@ impl GeneralReadout for LinuxGeneralReadout {
             let width = unsafe { XDisplayWidth(display, screen) };
             let height = unsafe { XDisplayHeight(display, screen) };
 
+            unsafe { XCloseDisplay(display) };
+            unsafe {
+                libc::free(display_name as *mut libc::c_void);
+            }
+
             return Ok(format!("{}x{}", width, height));
-        }
+        } else {
+            let drm = std::path::Path::new("/sys/class/drm");
+            if drm.is_dir() {
+                let dirs = extra::list_dir_entries(drm);
+                let mut resolution = String::new();
+                for entry in dirs {
+                    if entry.read_link().is_ok() {
+                        let modes = std::path::PathBuf::from(entry).join("modes");
+                        if modes.is_file() {
+                            if let Ok(mut this_res) = std::fs::read_to_string(modes) {
+                                if this_res.ends_with("\n") {
+                                    this_res.pop();
+                                }
+                                resolution.push_str(&this_res);
+                                resolution.push_str(", ");
+                            }
+                        }
+                    }
+                }
 
-        unsafe { XCloseDisplay(display) };
+                if resolution.trim_end().ends_with(",") {
+                    resolution.pop();
+                }
 
-        unsafe {
-            libc::free(display_name as *mut libc::c_void);
+                return Ok(resolution);
+            }
         }
 
         Err(ReadoutError::Other(String::from(

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -156,11 +156,13 @@ impl GeneralReadout for NetBSDGeneralReadout {
                         let modes = std::path::PathBuf::from(entry).join("modes");
                         if modes.is_file() {
                             if let Ok(mut this_res) = std::fs::read_to_string(modes) {
-                                if this_res.ends_with("\n") {
-                                    this_res.pop();
+                                if this_res.is_empty() {
+                                    if this_res.ends_with("\n") {
+                                        this_res.pop();
+                                    }
+                                    resolution.push_str(&this_res);
+                                    resolution.push_str(", ");
                                 }
-                                resolution.push_str(&this_res);
-                                resolution.push_str(", ");
                             }
                         }
                     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -375,6 +375,10 @@ pub trait GeneralReadout {
         Err(STANDARD_NO_IMPL.clone())
     }
 
+    fn resolution(&self) -> Result<String, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
     /// This function should return the username of the currently logged on user.
     ///
     /// _e.g._ `johndoe`

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -371,6 +371,10 @@ pub trait GeneralReadout {
     /// Creates a new instance of the structure which implements this trait.
     fn new() -> Self;
 
+    fn backlight(&self) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
     /// This function should return the username of the currently logged on user.
     ///
     /// _e.g._ `johndoe`


### PR DESCRIPTION
Added a basic (X11 only) resolution implementation using X11 bindings.
It should theoretically work on NetBSD just as it does on Linux.

## Next up
- Wayland support, the Linux world has been moving slowly but steadily towards adopting Wayland and a lot of people are running it as their daily driver.
- This method requires that the user is in a graphical environment, resolution will fail to fetch in a TTY.

**I can confirm this works on my one screen setup, but more testing should be done.**