### PR TITLE
🐛 Fix Resolution Readout for NetBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,12 @@ sysctl = "0.4.1"
 [target.'cfg(any(target_os = "linux", target_os = "netbsd"))'.build-dependencies]
 pkg-config = "0.3.19"
 
+[profile.dev]
+rpath = true
+
+[profile.release]
+rpath = true
+
 [features]
 openwrt = []
 xserver = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmacchina"
-version = "0.4.9"
+version = "0.4.91"
 authors = ["grtcdr <ba.tahaaziz@gmail.com>", "Marvin Haschker <marvin@haschker.me>"]
 edition = "2018"
 description = "Provides the fetching capabilities for Macchina."

--- a/build.rs
+++ b/build.rs
@@ -13,14 +13,19 @@ fn build_linux_netbsd() {
     // or we can search a hardcoded directory.
     #[cfg(target_os = "netbsd")]
     if let Some(x11_dir) = option_env!("LIBMAC_X11_LIB_PATH") {
-        println!("cargo:rustc-link-search={}", x11_dir);
+        println!("cargo:rustc-link-search=native={}", x11_dir);
     } else {
-        println!("cargo:rustc-link-search={}", "/usr/X11R7/lib");
+        println!("cargo:rustc-link-search=native={}", "/usr/X11R7/lib");
     }
 
     #[cfg(any(target_os = "linux", target_os = "netbsd"))]
     match pkg_config::probe_library("x11") {
         Ok(_) => {
+            if cfg!(target_os = "netbsd") {
+                println!("cargo:rustc-link-lib=xcb");
+                println!("cargo:rustc-link-lib=Xau");
+                println!("cargo:rustc-link-lib=Xdmcp");
+            }
             println!("cargo:rustc-link-lib=X11");
             println!("cargo:rustc-cfg=feature=\"xserver\"");
         }

--- a/build.rs
+++ b/build.rs
@@ -9,8 +9,15 @@ fn build_windows() {
 }
 
 fn build_linux_netbsd() {
+    // The user can specify the path to the X11 library
+    // or we can search a hardcoded directory.
     #[cfg(target_os = "netbsd")]
-    println!("cargo:rustc-link-search=/usr/X11R7/lib");
+    if let Some(x11_dir) = option_env!("LIBMAC_X11_LIB_PATH") {
+        println!("cargo:rustc-link-search={}", x11_dir);
+    } else {
+        println!("cargo:rustc-link-search={}", "/usr/X11R7/lib");
+    }
+
     #[cfg(any(target_os = "linux", target_os = "netbsd"))]
     match pkg_config::probe_library("x11") {
         Ok(_) => {

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,8 @@ fn build_windows() {
 }
 
 fn build_linux_netbsd() {
+    #[cfg(target_os = "netbsd")]
+    println!("cargo:rustc-link-search=/usr/X11R7/lib");
     #[cfg(any(target_os = "linux", target_os = "netbsd"))]
     match pkg_config::probe_library("x11") {
         Ok(_) => {

--- a/build.rs
+++ b/build.rs
@@ -22,11 +22,11 @@ fn build_linux_netbsd() {
     match pkg_config::probe_library("x11") {
         Ok(_) => {
             if cfg!(target_os = "netbsd") {
-                println!("cargo:rustc-link-lib=xcb");
-                println!("cargo:rustc-link-lib=Xau");
-                println!("cargo:rustc-link-lib=Xdmcp");
+                println!("cargo:rustc-link-lib=static=xcb");
+                println!("cargo:rustc-link-lib=static=Xau");
+                println!("cargo:rustc-link-lib=static=Xdmcp");
             }
-            println!("cargo:rustc-link-lib=X11");
+            println!("cargo:rustc-link-lib=static=X11");
             println!("cargo:rustc-cfg=feature=\"xserver\"");
         }
         Err(_) => println!("X11 not present"),

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -140,7 +140,7 @@ impl GeneralReadout for NetBSDGeneralReadout {
                 true => {
                     return Err(ReadoutError::Other(String::from(
                         "Failed to fetch resolution through sysctl, is ACPIVGA driver installed?",
-                    )))
+                    )));
                 }
                 _ => {
                     return Ok(String::from(brightness));

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -127,7 +127,7 @@ impl GeneralReadout for NetBSDGeneralReadout {
 
     fn resolution(&self) -> Result<String, ReadoutError> {
         // ACPIVGA driver is required for this to function
-        fn get_resolution_through_sysctl() {
+        fn get_resolution_through_sysctl() -> Result<String, ReadoutError> {
             let output = Command::new("sysctl")
                 .args(&["-n", "-b", "hw.acpi.acpiout0.brightness"])
                 .output()

--- a/src/netbsd/x11_ffi.rs
+++ b/src/netbsd/x11_ffi.rs
@@ -3,6 +3,7 @@ use std::os::raw::{c_char, c_int};
 pub enum _XDisplay {}
 type Display = _XDisplay;
 
+#[link(name = "X11")]
 extern "C" {
     pub fn XOpenDisplay(_1: *const c_char) -> *mut Display;
     pub fn XCloseDisplay(_1: *mut Display) -> c_int;


### PR DESCRIPTION
X11 libraries weren't being properly linked, this PR solves this issue.

It also provides a way to tell libmacchina where to find X11 libraries (instead of a hardcoded path, `/usr/X11R7/lib` through an environment variable called `LIBMAC_X11_LIB_PATH`.