### PR TITLE
libmacchina show commit hash in version info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmacchina"
-version = "0.7.9"
+version = "0.8.0"
 authors = ["grtcdr <ba.tahaaziz@gmail.com>", "Marvin Haschker <marvin@haschker.me>"]
 edition = "2018"
 description = "A library that can fetch all sorts of system information, super-duper fast!"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ rpath = true
 [features]
 openwrt = []
 xserver = []
+
+[build-dependencies]
+vergen = "5.1.15"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 use std::env;
-
+use vergen::{ShaKind,Config};
 fn build_windows() {
     #[cfg(windows)]
     windows::build!(
@@ -48,4 +48,9 @@ fn main() {
         Ok("linux") | Ok("netbsd") => build_linux_netbsd(),
         _ => {}
     }
+
+    let mut config = Config::default();
+    *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    // This will break builds if the git folder is removed
+    vergen::vergen(config).unwrap(); 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,11 @@ pub struct Readouts {
     pub packages: PackageReadout,
 }
 
+pub fn version() -> &'static str {
+    return concat!(env!("CARGO_PKG_VERSION"), " (", env!("VERGEN_GIT_SHA_SHORT"), ")");
+}
+
+
 pub mod extra;
 mod shared;
 pub mod traits;


### PR DESCRIPTION
Added a function in lib.rs called function which returns a static string containing the version and commit hash.