### PR TITLE
NetBSD: use statvfs rather than statfs to query used disk space

### DIFF
--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -297,7 +297,26 @@ impl GeneralReadout for NetBSDGeneralReadout {
     }
     
     fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
-        crate::shared::disk_space(String::from("/"))
+        let mut s: std::mem::MaybeUninit<libc::statvfs> = std::mem::MaybeUninit::uninit();
+        let path = CString::new("/").expect("Could not create C string for disk usage path.");
+    
+        if unsafe { libc::statvfs(path.as_ptr(), s.as_mut_ptr()) } == 0 {
+            let stats: libc::statfs = unsafe { s.assume_init() };
+    
+            let disk_size = stats.f_blocks * stats.f_bsize as u64;
+            let free = stats.f_bavail * stats.f_bsize as u64;
+    
+            let used_byte =
+                byte_unit::Byte::from_bytes((disk_size - free) as u128).get_appropriate_unit(true);
+            let disk_size_byte =
+                byte_unit::Byte::from_bytes(disk_size as u128).get_adjusted_unit(used_byte.get_unit());
+    
+            return Ok((used_byte, disk_size_byte));
+        }
+    
+        Err(ReadoutError::Other(String::from(
+            "Error while trying to get statfs structure.",
+        )))
     }
 }
 

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -2,6 +2,7 @@ use crate::extra;
 use crate::traits::*;
 use itertools::Itertools;
 use nix::unistd;
+use std::ffi::CString;
 use byte_unit::AdjustedByte;
 use regex::Regex;
 use std::fs;
@@ -301,7 +302,7 @@ impl GeneralReadout for NetBSDGeneralReadout {
         let path = CString::new("/").expect("Could not create C string for disk usage path.");
     
         if unsafe { libc::statvfs(path.as_ptr(), s.as_mut_ptr()) } == 0 {
-            let stats: libc::statfs = unsafe { s.assume_init() };
+            let stats: libc::statvfs = unsafe { s.assume_init() };
     
             let disk_size = stats.f_blocks * stats.f_bsize as u64;
             let free = stats.f_bavail * stats.f_bsize as u64;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -232,7 +232,7 @@ pub(crate) fn cpu_physical_cores() -> Result<usize, ReadoutError> {
     Ok(num_cpus::get_physical())
 }
 
-#[cfg(target_family = "unix")]
+#[cfg(any(not(target_os = "netbsd"), target_family="unix"))]
 pub(crate) fn disk_space(path: String) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
     let mut s: std::mem::MaybeUninit<libc::statfs> = std::mem::MaybeUninit::uninit();
     let path = CString::new(path).expect("Could not create C string for disk usage path.");

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -232,7 +232,7 @@ pub(crate) fn cpu_physical_cores() -> Result<usize, ReadoutError> {
     Ok(num_cpus::get_physical())
 }
 
-#[cfg(any(not(target_os = "netbsd"), target_family="unix"))]
+#[cfg(not(any(target_os = "netbsd", target_os = "windows")))]
 pub(crate) fn disk_space(path: String) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
     let mut s: std::mem::MaybeUninit<libc::statfs> = std::mem::MaybeUninit::uninit();
     let path = CString::new(path).expect("Could not create C string for disk usage path.");


### PR DESCRIPTION
This won't fix macchina's build errors on the NetBSD side because of a version incompatibility it is currently experiencing.