### PR TITLE
netbsd::GeneralReadout::resolution: return MetricNotAvailable

### DIFF
--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -127,24 +127,7 @@ impl GeneralReadout for NetBSDGeneralReadout {
     }
 
     fn resolution(&self) -> Result<String, ReadoutError> {
-        let output = Command::new("sysctl")
-            .args(&["-n", "-b", "hw.acpi.acpiout0.brightness"])
-            .output()
-            .expect("ERROR: failed to fetch \"hw.acpi.acpiout0.brightness\" using \"sysctl\"");
-
-        let brightness = String::from_utf8(output.stdout)
-            .expect("ERROR: \"sysctl\" process stdout was not valid UTF-8");
-
-        match brightness.is_empty() {
-            true => {
-                return Err(ReadoutError::Other(String::from(
-                    "Failed to fetch resolution through sysctl, is ACPIVGA driver installed?",
-                )));
-            }
-            _ => {
-                return Ok(String::from(brightness));
-            }
-        }
+        Err(ReadoutError::MetricNotAvailable)
     }
 
     fn machine(&self) -> Result<String, ReadoutError> {


### PR DESCRIPTION
See the end of #55 for the reasons behind this PR.