### PR TITLE
fixed select on wrong table for count RPM packages

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -584,7 +584,7 @@ impl LinuxPackageReadout {
         let path = "/var/lib/rpm/rpmdb.sqlite";
         let connection = sqlite::open(path);
         if let Ok(con) = connection {
-            let statement = con.prepare("SELECT COUNT(*) FROM Installtid");
+            let statement = con.prepare("SELECT COUNT(*) FROM Installed");
             if let Ok(mut s) = statement {
                 if s.next().is_ok() {
                     return match s.read::<Option<i64>>(0) {


### PR DESCRIPTION
using fedora, I realized that didn't count the packages correctly, count flatpak but not RPM:

![image](https://user-images.githubusercontent.com/30029780/135722302-878c5348-97f5-4afc-bbe4-fb3a07d248f8.png)

I looked at the neofetch code to see what it was like and found the table name was wrong

in the database:
![image](https://user-images.githubusercontent.com/30029780/135722363-1de3fb71-9a3f-4d22-9692-6100e611428e.png)

in the libmacchina code:
![image](https://user-images.githubusercontent.com/30029780/135722394-ff7852a8-da38-4f01-ad6f-47ae0df5dc14.png)

