### PR TITLE
Use 'local-ip-address' crate instead of 'if-addrs'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = "1.0.0"
 libc = "0.2.106"
 lazy_static = "1.4.0"
 byte-unit = "4.0.12"
-if-addrs = "0.6.6"
+local-ip-address = "0.4.4"
 
 [target.'cfg(any(target_os="freebsd", target_os = "linux"))'.dependencies]
 sqlite = "0.26.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = "1.0.0"
 libc = "0.2.106"
 lazy_static = "1.4.0"
 byte-unit = "4.0.12"
-local-ip-address = "0.4.4"
+if-addrs = "0.6.6"
 
 [target.'cfg(any(target_os="freebsd", target_os = "linux"))'.dependencies]
 sqlite = "0.26.0"
@@ -39,6 +39,7 @@ num_cpus = "1.13.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = "0.4.0"
 winreg = "0.8.0"
+local-ip-address = "0.4.4"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 windows = "0.4.0"

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -220,7 +220,24 @@ impl GeneralReadout for WindowsGeneralReadout {
     }
 
     fn local_ip(&self, interface: Option<String>) -> Result<String, ReadoutError> {
-        crate::shared::local_ip(interface)
+        match interface {
+            Some(it) => {
+                if let Ok(addresses) = local_ip_address::list_afinet_netifas() {
+                    if let Some((_, ip)) = local_ip_address::find_ifa(addresses, &it) {
+                        return Ok(ip.to_string());
+                    }
+                }
+            }
+            None => {
+                if let Ok(local_ip) = local_ip_address::local_ip() {
+                    return Ok(local_ip.to_string());
+                }
+            }
+        };
+
+        return Err(ReadoutError::Other(String::from(
+            "Unable to get local IP address.",
+        )));
     }
 
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {


### PR DESCRIPTION
This change fixes #88 but since the discussion there was not final, I would understand if the alternative method would be preferred.

The implementation in this pull request would also allow to not specify an interface. In this case the `local-ip-address` crate chooses some sensible defaults to determine the local IP address.