### PR TITLE
Refactoring of ProductReadout

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -125,18 +125,18 @@ impl GeneralReadout for AndroidGeneralReadout {
     fn machine(&self) -> Result<String, ReadoutError> {
         let product_readout = AndroidProductReadout::new();
 
-        let name = product_readout.name()?;
-        let version = product_readout.version()?;
         let vendor = product_readout.vendor()?;
+        let family = product_readout.family()?;
+        let product = product_readout.product()?;
 
-        let product = format!("{} {} ({})", vendor, name, version);
+        let product = format!("{} {} ({})", vendor, family, product);
         let new_product: Vec<_> = product.split_whitespace().into_iter().unique().collect();
 
-        if version.is_empty() || version.len() <= 15 {
+        if product.is_empty() || product.len() <= 15 {
             return Ok(new_product.into_iter().join(" "));
         }
 
-        Ok(version)
+        Ok(product)
     }
 
     fn local_ip(&self, interface: Option<String>) -> Result<String, ReadoutError> {
@@ -326,7 +326,7 @@ impl ProductReadout for AndroidProductReadout {
         AndroidProductReadout
     }
 
-    fn name(&self) -> Result<String, ReadoutError> {
+    fn family(&self) -> Result<String, ReadoutError> {
         getprop("ro.product.model").ok_or(ReadoutError::Other("getprop failed".to_string()))
         // ro.product.model
         // ro.product.odm.model
@@ -354,7 +354,7 @@ impl ProductReadout for AndroidProductReadout {
         // Same in all cases ( needs more testing in other devices )
     }
 
-    fn version(&self) -> Result<String, ReadoutError> {
+    fn product(&self) -> Result<String, ReadoutError> {
         getprop("ro.build.product").ok_or(ReadoutError::Other("getprop failed".to_string()))
         // ro.build.product
         // ro.product.device

--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -321,7 +321,7 @@ impl ProductReadout for FreeBSDProductReadout {
         FreeBSDProductReadout
     }
 
-    fn version(&self) -> Result<String, ReadoutError> {
+    fn family(&self) -> Result<String, ReadoutError> {
         Err(ReadoutError::MetricNotAvailable)
     }
 

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -161,18 +161,22 @@ impl GeneralReadout for NetBSDGeneralReadout {
     fn machine(&self) -> Result<String, ReadoutError> {
         let product_readout = NetBSDProductReadout::new();
 
-        let product = product_readout.product()?;
+        let family = product_readout.family()?;
         let vendor = product_readout.vendor()?;
-        let version = product_readout.version()?;
+        let product = product_readout.product()?;
 
-        let product =
-            format!("{} {} {}", vendor, product, version).replace("To be filled by O.E.M.", "");
+        let new_product =
+            format!("{} {} {}", vendor, family, product).replace("To be filled by O.E.M.", "");
 
-        let new_product: Vec<_> = product.split_whitespace().into_iter().unique().collect();
-
-        if version == product && version == vendor {
+        if product == new_product && product == vendor {
             return Ok(vendor);
         }
+
+        let new_product: Vec<_> = new_product
+            .split_whitespace()
+            .into_iter()
+            .unique()
+            .collect();
 
         Ok(new_product.into_iter().join(" "))
     }
@@ -369,7 +373,7 @@ impl ProductReadout for NetBSDProductReadout {
         NetBSDProductReadout
     }
 
-    fn version(&self) -> Result<String, ReadoutError> {
+    fn product(&self) -> Result<String, ReadoutError> {
         let output = Command::new("sysctl")
             .args(&["-n", "-b", "machdep.dmi.system-version"])
             .output()
@@ -393,7 +397,7 @@ impl ProductReadout for NetBSDProductReadout {
         Ok(String::from(sysven))
     }
 
-    fn product(&self) -> Result<String, ReadoutError> {
+    fn family(&self) -> Result<String, ReadoutError> {
         let output = Command::new("sysctl")
             .args(&["-n", "-b", "machdep.dmi.system-product"])
             .output()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -258,7 +258,7 @@ pub trait PackageReadout {
 
 /**
 This trait provides the interface for implementing functionality used for getting _product information_
-about the hosts operating system.
+about the host machine.
 
 # Example
 
@@ -278,16 +278,11 @@ impl ProductReadout for MacOSProductReadout {
     }
 
     fn family(&self) -> Result<String, ReadoutError> {
-        Ok(String::from("Unix, Macintosh"))
-    }
-
-    fn name(&self) -> Result<String, ReadoutError> {
-        // Get name of os release...
-        Ok(String::from("Big Sur"))
+        Ok(String::from("MacBook Pro"))
     }
 
     fn product(&self) -> Result<String, ReadoutError> {
-        Ok(String::from("macOS"))
+        Ok(String::from("MacBookPro16,1"))
     }
 }
 ```
@@ -295,15 +290,6 @@ impl ProductReadout for MacOSProductReadout {
 pub trait ProductReadout {
     /// Creates a new instance of the structure which implements this trait.
     fn new() -> Self;
-
-    /// This function should return the version of the host's machine.
-    ///
-    /// _e.g._ `Lenovo IdeaPad S540-15IWL GTX`
-    ///
-    /// This is set by the machine's manufacturer.
-    fn version(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
-    }
 
     /// This function should return the vendor name of the host's machine.
     ///
@@ -323,18 +309,9 @@ pub trait ProductReadout {
         Err(STANDARD_NO_IMPL.clone())
     }
 
-    /// This function should return the name of the host's machine.
+    /// This function should return the product name of the host's machine.
     ///
     /// _e.g._ `81SW`
-    ///
-    /// This is set by the machine's manufacturer.
-    fn name(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
-    }
-
-    /// This function should return the product name of the hosts machine.
-    ///
-    /// _e.g._ `IdeaPad S540-15IWL GTX`
     ///
     /// This is set by the machine's manufacturer.
     fn product(&self) -> Result<String, ReadoutError> {


### PR DESCRIPTION
This is the refactoring mentioned in #95.

**Summary:**
- Removes `version()` and `name()` from `ProductReadout`
- Fixes documentation for `ProductReadout` to not be mistaken for operating system information
- Fix the implementation for macOS & Windows that reported OS information instead of device information

⚠ **Important:** Please double check the implementation for anything but Windows, because I don't have a running system of those types.