### PR TITLE
BREAKING CHANGE: Introduce a new readout trait, "NetworkReadout".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ sysctl = "0.4.3"
 pkg-config = "0.3.22"
 
 [build-dependencies]
-vergen = { version = "5.1.18", default-features = false, features = ["build","cargo","git","rustc"] }
+vergen = { version = "5.1.17", default-features = false, features = ["build","cargo","git","rustc"] }
 
 [features]
 openwrt = []

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -2,6 +2,7 @@ mod sysinfo_ffi;
 mod system_properties;
 
 use crate::extra;
+use crate::shared;
 use crate::traits::*;
 use itertools::Itertools;
 use std::ffi::{CStr, CString};
@@ -37,8 +38,8 @@ pub struct AndroidMemoryReadout {
 }
 
 pub struct AndroidProductReadout;
-
 pub struct AndroidPackageReadout;
+pub struct AndroidNetworkReadout;
 
 impl BatteryReadout for AndroidBatteryReadout {
     fn new() -> Self {
@@ -139,8 +140,8 @@ impl GeneralReadout for AndroidGeneralReadout {
         Ok(product)
     }
 
-    fn local_ip(&self, interface: Option<String>) -> Result<String, ReadoutError> {
-        crate::shared::local_ip(interface)
+    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+        crate::shared::logical_address(interface)
     }
 
     fn username(&self) -> Result<String, ReadoutError> {
@@ -446,5 +447,15 @@ impl AndroidPackageReadout {
     /// that have `cargo` installed.
     fn count_cargo() -> Option<usize> {
         crate::shared::count_cargo()
+    }
+}
+
+impl NetworkReadout for AndroidNetworkReadout {
+    fn new() -> Self {
+        AndroidNetworkReadout
+    }
+
+    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+        shared::logical_address(interface)
     }
 }

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -140,12 +140,8 @@ impl GeneralReadout for AndroidGeneralReadout {
         Ok(product)
     }
 
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
-        crate::shared::logical_address(interface)
-    }
-
     fn username(&self) -> Result<String, ReadoutError> {
-        crate::shared::username()
+        shared::username()
     }
 
     fn hostname(&self) -> Result<String, ReadoutError> {
@@ -168,7 +164,7 @@ impl GeneralReadout for AndroidGeneralReadout {
             }
         }
 
-        return crate::shared::shell(format, kind);
+        return shared::shell(format, kind);
     }
 
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
@@ -217,11 +213,11 @@ impl GeneralReadout for AndroidGeneralReadout {
     }
 
     fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_physical_cores()
+        shared::cpu_physical_cores()
     }
 
     fn cpu_cores(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_cores()
+        shared::cpu_cores()
     }
 
     fn cpu_usage(&self) -> Result<usize, ReadoutError> {
@@ -304,11 +300,11 @@ impl MemoryReadout for AndroidMemoryReadout {
     }
 
     fn cached(&self) -> Result<u64, ReadoutError> {
-        Ok(crate::shared::get_meminfo_value("Cached"))
+        Ok(shared::get_meminfo_value("Cached"))
     }
 
     fn reclaimable(&self) -> Result<u64, ReadoutError> {
-        Ok(crate::shared::get_meminfo_value("SReclaimable"))
+        Ok(shared::get_meminfo_value("SReclaimable"))
     }
 
     fn used(&self) -> Result<u64, ReadoutError> {
@@ -446,7 +442,7 @@ impl AndroidPackageReadout {
     /// Returns the number of installed packages for systems
     /// that have `cargo` installed.
     fn count_cargo() -> Option<usize> {
-        crate::shared::count_cargo()
+        shared::count_cargo()
     }
 }
 
@@ -455,7 +451,7 @@ impl NetworkReadout for AndroidNetworkReadout {
         AndroidNetworkReadout
     }
 
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
     }
 }

--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -35,8 +35,8 @@ pub struct FreeBSDMemoryReadout {
 }
 
 pub struct FreeBSDProductReadout;
-
 pub struct FreeBSDPackageReadout;
+pub struct FreeBSDNetworkReadout;
 
 impl BatteryReadout for FreeBSDBatteryReadout {
     fn new() -> Self {
@@ -120,7 +120,7 @@ impl GeneralReadout for FreeBSDGeneralReadout {
     }
 
     fn resolution(&self) -> Result<String, ReadoutError> {
-        crate::shared::resolution()
+        shared::resolution()
     }
 
     fn backlight(&self) -> Result<usize, ReadoutError> {
@@ -129,10 +129,6 @@ impl GeneralReadout for FreeBSDGeneralReadout {
 
     fn machine(&self) -> Result<String, ReadoutError> {
         Err(ReadoutError::MetricNotAvailable)
-    }
-
-    fn local_ip(&self, interface: Option<String>) -> Result<String, ReadoutError> {
-        shared::local_ip(interface)
     }
 
     fn username(&self) -> Result<String, ReadoutError> {
@@ -157,7 +153,7 @@ impl GeneralReadout for FreeBSDGeneralReadout {
     }
 
     fn session(&self) -> Result<String, ReadoutError> {
-        crate::shared::session()
+        shared::session()
     }
 
     fn window_manager(&self) -> Result<String, ReadoutError> {
@@ -379,5 +375,15 @@ impl FreeBSDPackageReadout {
 
     fn count_cargo() -> Option<usize> {
         crate::shared::count_cargo()
+    }
+}
+
+impl NetworkReadout for FreeBSDNetworkReadout {
+    fn new() -> Self {
+        FreeBSDNetworkReadout
+    }
+
+    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+        shared::logical_address(interface)
     }
 }

--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -374,7 +374,7 @@ impl FreeBSDPackageReadout {
     }
 
     fn count_cargo() -> Option<usize> {
-        crate::shared::count_cargo()
+        shared::count_cargo()
     }
 }
 
@@ -383,7 +383,7 @@ impl NetworkReadout for FreeBSDNetworkReadout {
         FreeBSDNetworkReadout
     }
 
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ cfg_if! {
         pub type GeneralReadout = openwrt::OpenWrtGeneralReadout;
         pub type ProductReadout = openwrt::OpenWrtProductReadout;
         pub type PackageReadout = openwrt::OpenWrtPackageReadout;
+        pub type NetworkReadout = openwrt::OpenWrtNetworkReadout;
     } else if #[cfg(all(target_os = "linux", not(feature = "openwrt")))] {
         mod linux;
         mod winman;
@@ -23,6 +24,7 @@ cfg_if! {
         pub type GeneralReadout = linux::LinuxGeneralReadout;
         pub type ProductReadout = linux::LinuxProductReadout;
         pub type PackageReadout = linux::LinuxPackageReadout;
+        pub type NetworkReadout = linux::LinuxNetworkReadout;
     } else if #[cfg(target_os = "macos")] {
         mod macos;
 
@@ -32,6 +34,7 @@ cfg_if! {
         pub type GeneralReadout = macos::MacOSGeneralReadout;
         pub type ProductReadout = macos::MacOSProductReadout;
         pub type PackageReadout = macos::MacOSPackageReadout;
+        pub type NetworkReadout = macos::MacOSNetworkReadout;
     } else if #[cfg(target_os = "netbsd")] {
         mod netbsd;
         mod winman;
@@ -42,6 +45,7 @@ cfg_if! {
         pub type GeneralReadout = netbsd::NetBSDGeneralReadout;
         pub type ProductReadout = netbsd::NetBSDProductReadout;
         pub type PackageReadout = netbsd::NetBSDPackageReadout;
+        pub type NetworkReadout = netbsd::NetBSDNetworkReadout;
     } else if #[cfg(target_os = "windows")] {
         mod windows;
 
@@ -51,6 +55,7 @@ cfg_if! {
         pub type GeneralReadout = windows::WindowsGeneralReadout;
         pub type ProductReadout = windows::WindowsProductReadout;
         pub type PackageReadout = windows::WindowsPackageReadout;
+        pub type NetworkReadout = windows::WindowsNetworkReadout;
     } else if #[cfg(target_os = "android")] {
         mod android;
 
@@ -60,6 +65,7 @@ cfg_if! {
         pub type GeneralReadout = android::AndroidGeneralReadout;
         pub type ProductReadout = android::AndroidProductReadout;
         pub type PackageReadout = android::AndroidPackageReadout;
+        pub type NetworkReadout = android::AndroidNetworkReadout;
     } else if #[cfg(target_os = "freebsd")] {
         mod freebsd;
         mod winman;
@@ -70,6 +76,7 @@ cfg_if! {
         pub type GeneralReadout = freebsd::FreeBSDGeneralReadout;
         pub type ProductReadout = freebsd::FreeBSDProductReadout;
         pub type PackageReadout = freebsd::FreeBSDPackageReadout;
+        pub type NetworkReadout = freebsd::FreeBSDNetworkReadout;
     } else {
         compiler_error!("This platform is currently not supported by libmacchina.");
     }
@@ -82,6 +89,7 @@ pub struct Readouts {
     pub general: GeneralReadout,
     pub product: ProductReadout,
     pub packages: PackageReadout,
+    pub network: PackageReadout,
 }
 
 pub fn version() -> &'static str {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -173,7 +173,7 @@ impl NetworkReadout for LinuxNetworkReadout {
         LinuxNetworkReadout
     }
 
-    fn tx_bytes(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+    fn tx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
         if let Some(_if) = interface {
             let rx_file = PathBuf::from("/sys/class/net")
                 .join(_if)
@@ -188,7 +188,7 @@ impl NetworkReadout for LinuxNetworkReadout {
         }
     }
 
-    fn tx_packets(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+    fn tx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
         if let Some(_if) = interface {
             let rx_file = PathBuf::from("/sys/class/net")
                 .join(_if)
@@ -203,7 +203,7 @@ impl NetworkReadout for LinuxNetworkReadout {
         }
     }
 
-    fn rx_bytes(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+    fn rx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
         if let Some(_if) = interface {
             let rx_file = PathBuf::from("/sys/class/net")
                 .join(_if)
@@ -218,7 +218,7 @@ impl NetworkReadout for LinuxNetworkReadout {
         }
     }
 
-    fn rx_packets(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+    fn rx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
         if let Some(_if) = interface {
             let rx_file = PathBuf::from("/sys/class/net")
                 .join(_if)
@@ -233,7 +233,7 @@ impl NetworkReadout for LinuxNetworkReadout {
         }
     }
 
-    fn physical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn physical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         if let Some(_if) = interface {
             let rx_file = PathBuf::from("/sys/class/net").join(_if).join("address");
             let content = std::fs::read_to_string(rx_file)?;
@@ -245,7 +245,7 @@ impl NetworkReadout for LinuxNetworkReadout {
         }
     }
 
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
     }
 }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -179,7 +179,7 @@ impl NetworkReadout for LinuxNetworkReadout {
                 .join(_if)
                 .join("statistics/tx_bytes");
             let content = std::fs::read_to_string(rx_file)?;
-            let bytes = content.parse::<usize>().unwrap_or_default();
+            let bytes = extra::pop_newline(content).parse::<usize>().unwrap_or_default();
             Ok(bytes)
         } else {
             Err(ReadoutError::Other(String::from(
@@ -194,7 +194,7 @@ impl NetworkReadout for LinuxNetworkReadout {
                 .join(_if)
                 .join("statistics/tx_packets");
             let content = std::fs::read_to_string(rx_file)?;
-            let packets = content.parse::<usize>().unwrap_or_default();
+            let packets = extra::pop_newline(content).parse::<usize>().unwrap_or_default();
             Ok(packets)
         } else {
             Err(ReadoutError::Other(String::from(
@@ -209,7 +209,7 @@ impl NetworkReadout for LinuxNetworkReadout {
                 .join(_if)
                 .join("statistics/rx_bytes");
             let content = std::fs::read_to_string(rx_file)?;
-            let bytes = content.parse::<usize>().unwrap_or_default();
+            let bytes = extra::pop_newline(content).parse::<usize>().unwrap_or_default();
             Ok(bytes)
         } else {
             Err(ReadoutError::Other(String::from(
@@ -224,7 +224,7 @@ impl NetworkReadout for LinuxNetworkReadout {
                 .join(_if)
                 .join("statistics/rx_packets");
             let content = std::fs::read_to_string(rx_file)?;
-            let packets = content.parse::<usize>().unwrap_or_default();
+            let packets = extra::pop_newline(content).parse::<usize>().unwrap_or_default();
             Ok(packets)
         } else {
             Err(ReadoutError::Other(String::from(

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -588,7 +588,7 @@ impl NetworkReadout for MacOSNetworkReadout {
         MacOSNetworkReadout
     }
 
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
     }
 }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,4 +1,5 @@
 use crate::extra;
+use crate::shared;
 use crate::macos::mach_ffi::{io_registry_entry_t, IOObjectRelease};
 use crate::macos::mach_ffi::{
     kIOMasterPortDefault, vm_statistics64, IORegistryEntryCreateCFProperties,
@@ -51,6 +52,7 @@ struct MacOSIOPMPowerSource {
 }
 
 pub struct MacOSPackageReadout;
+pub struct MacOSNetworkReadout;
 
 impl BatteryReadout for MacOSBatteryReadout {
     fn new() -> Self {
@@ -245,7 +247,7 @@ impl GeneralReadout for MacOSGeneralReadout {
     }
 
     fn username(&self) -> Result<String, ReadoutError> {
-        crate::shared::username()
+        shared::username()
     }
 
     fn hostname(&self) -> Result<String, ReadoutError> {
@@ -260,10 +262,6 @@ impl GeneralReadout for MacOSGeneralReadout {
         Err(ReadoutError::Warning(String::from(
             "Since you're on macOS, there is no distribution to be read from the system.",
         )))
-    }
-
-    fn local_ip(&self, interface: Option<String>) -> Result<String, ReadoutError> {
-        crate::shared::local_ip(interface)
     }
 
     fn desktop_environment(&self) -> Result<String, ReadoutError> {
@@ -304,7 +302,7 @@ impl GeneralReadout for MacOSGeneralReadout {
     }
 
     fn shell(&self, shorthand: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError> {
-        crate::shared::shell(shorthand, kind)
+        shared::shell(shorthand, kind)
     }
 
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
@@ -316,15 +314,15 @@ impl GeneralReadout for MacOSGeneralReadout {
     }
 
     fn cpu_usage(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_usage()
+        shared::cpu_usage()
     }
 
     fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_physical_cores()
+        shared::cpu_physical_cores()
     }
 
     fn cpu_cores(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_cores()
+        shared::cpu_cores()
     }
 
     fn uptime(&self) -> Result<usize, ReadoutError> {
@@ -363,7 +361,7 @@ impl GeneralReadout for MacOSGeneralReadout {
     }
 
     fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
-        crate::shared::disk_space(String::from("/"))
+        shared::disk_space(String::from("/"))
     }
 }
 
@@ -581,7 +579,17 @@ impl MacOSPackageReadout {
     }
 
     fn count_cargo() -> Option<usize> {
-        crate::shared::count_cargo()
+        shared::count_cargo()
+    }
+}
+
+impl NetworkReadout for MacOSNetworkReadout {
+    fn new() -> Self {
+        MacOSNetworkReadout
+    }
+
+    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+        shared::logical_address(interface)
     }
 }
 

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -459,7 +459,7 @@ impl NetworkReadout for NetBSDNetworkReadout {
         NetBSDNetworkReadout
     }
 
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
     }
 }

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -1,5 +1,6 @@
 use crate::dirs;
 use crate::extra;
+use crate::shared;
 use crate::traits::*;
 use byte_unit::AdjustedByte;
 use itertools::Itertools;
@@ -12,16 +13,12 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 pub struct NetBSDBatteryReadout;
-
 pub struct NetBSDKernelReadout;
-
 pub struct NetBSDGeneralReadout;
-
 pub struct NetBSDMemoryReadout;
-
 pub struct NetBSDProductReadout;
-
 pub struct NetBSDPackageReadout;
+pub struct NetBSDNetworkReadout;
 
 impl BatteryReadout for NetBSDBatteryReadout {
     fn new() -> Self {
@@ -131,7 +128,7 @@ impl GeneralReadout for NetBSDGeneralReadout {
     }
 
     fn resolution(&self) -> Result<String, ReadoutError> {
-        crate::shared::resolution()
+        shared::resolution()
     }
 
     fn backlight(&self) -> Result<usize, ReadoutError> {
@@ -181,12 +178,8 @@ impl GeneralReadout for NetBSDGeneralReadout {
         Ok(new_product.into_iter().join(" "))
     }
 
-    fn local_ip(&self, interface: Option<String>) -> Result<String, ReadoutError> {
-        crate::shared::local_ip(interface)
-    }
-
     fn username(&self) -> Result<String, ReadoutError> {
-        crate::shared::username()
+        shared::username()
     }
 
     fn hostname(&self) -> Result<String, ReadoutError> {
@@ -210,11 +203,11 @@ impl GeneralReadout for NetBSDGeneralReadout {
     }
 
     fn desktop_environment(&self) -> Result<String, ReadoutError> {
-        crate::shared::desktop_environment()
+        shared::desktop_environment()
     }
 
     fn session(&self) -> Result<String, ReadoutError> {
-        crate::shared::session()
+        shared::session()
     }
 
     fn window_manager(&self) -> Result<String, ReadoutError> {
@@ -287,27 +280,27 @@ impl GeneralReadout for NetBSDGeneralReadout {
     }
 
     fn shell(&self, shorthand: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError> {
-        crate::shared::shell(shorthand, kind)
+        shared::shell(shorthand, kind)
     }
 
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
-        Ok(crate::shared::cpu_model_name())
+        Ok(shared::cpu_model_name())
     }
 
     fn cpu_cores(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_cores()
+        shared::cpu_cores()
     }
 
     fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_physical_cores()
+        shared::cpu_physical_cores()
     }
 
     fn cpu_usage(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_usage()
+        shared::cpu_usage()
     }
 
     fn uptime(&self) -> Result<usize, ReadoutError> {
-        crate::shared::uptime()
+        shared::uptime()
     }
 
     fn os_name(&self) -> Result<String, ReadoutError> {
@@ -353,11 +346,11 @@ impl MemoryReadout for NetBSDMemoryReadout {
     }
 
     fn total(&self) -> Result<u64, ReadoutError> {
-        Ok(crate::shared::get_meminfo_value("MemTotal"))
+        Ok(shared::get_meminfo_value("MemTotal"))
     }
 
     fn free(&self) -> Result<u64, ReadoutError> {
-        Ok(crate::shared::get_meminfo_value("MemFree"))
+        Ok(shared::get_meminfo_value("MemFree"))
     }
 
     fn used(&self) -> Result<u64, ReadoutError> {
@@ -456,6 +449,17 @@ impl NetBSDPackageReadout {
     }
 
     fn count_cargo() -> Option<usize> {
-        crate::shared::count_cargo()
+        shared::count_cargo()
+    }
+}
+
+
+impl NetworkReadout for NetBSDNetworkReadout {
+    fn new() -> Self {
+        NetBSDNetworkReadout
+    }
+
+    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+        shared::logical_address(interface)
     }
 }

--- a/src/openwrt/mod.rs
+++ b/src/openwrt/mod.rs
@@ -295,7 +295,7 @@ impl NetworkReadout for OpenWrtNetworkReadout {
         OpenWrtNetworkReadout
     }
 
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
     }
 }

--- a/src/openwrt/mod.rs
+++ b/src/openwrt/mod.rs
@@ -1,6 +1,7 @@
 mod sysinfo_ffi;
 
 use crate::extra;
+use crate::shared;
 use crate::traits::*;
 use byte_unit::AdjustedByte;
 use std::fs;
@@ -25,8 +26,8 @@ pub struct OpenWrtMemoryReadout {
 }
 
 pub struct OpenWrtProductReadout;
-
 pub struct OpenWrtPackageReadout;
+pub struct OpenWrtNetworkReadout;
 
 impl BatteryReadout for OpenWrtBatteryReadout {
     fn new() -> Self {
@@ -88,12 +89,8 @@ impl GeneralReadout for OpenWrtGeneralReadout {
         )))
     }
 
-    fn local_ip(&self, interface: String) -> Result<String, ReadoutError> {
-        crate::shared::local_ip(interface)
-    }
-
     fn username(&self) -> Result<String, ReadoutError> {
-        crate::shared::username()
+        shared::username()
     }
 
     fn hostname(&self) -> Result<String, ReadoutError> {
@@ -115,7 +112,7 @@ impl GeneralReadout for OpenWrtGeneralReadout {
     }
 
     fn shell(&self, format: ShellFormat) -> Result<String, ReadoutError> {
-        crate::shared::shell(format)
+        shared::shell(format)
     }
 
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
@@ -139,11 +136,11 @@ impl GeneralReadout for OpenWrtGeneralReadout {
     }
 
     fn cpu_cores(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_cores()
+        shared::cpu_cores()
     }
 
     fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
-        crate::shared::cpu_physical_cores()
+        shared::cpu_physical_cores()
     }
 
     fn cpu_usage(&self) -> Result<usize, ReadoutError> {
@@ -176,7 +173,7 @@ impl GeneralReadout for OpenWrtGeneralReadout {
     }
 
     fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
-        crate::shared::disk_space(String::from("/"))
+        shared::disk_space(String::from("/"))
     }
 }
 
@@ -227,11 +224,11 @@ impl MemoryReadout for OpenWrtMemoryReadout {
     }
 
     fn cached(&self) -> Result<u64, ReadoutError> {
-        Ok(crate::shared::get_meminfo_value("Cached"))
+        Ok(shared::get_meminfo_value("Cached"))
     }
 
     fn reclaimable(&self) -> Result<u64, ReadoutError> {
-        Ok(crate::shared::get_meminfo_value("SReclaimable"))
+        Ok(shared::get_meminfo_value("SReclaimable"))
     }
 
     fn used(&self) -> Result<u64, ReadoutError> {
@@ -290,5 +287,15 @@ impl OpenWrtPackageReadout {
         }
 
         None
+    }
+}
+
+impl NetworkReadout for OpenWrtNetworkReadout {
+    fn new() -> Self {
+        OpenWrtNetworkReadout
+    }
+
+    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+        shared::logical_address(interface)
     }
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -303,7 +303,7 @@ pub(crate) fn get_meminfo_value(value: &str) -> u64 {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub(crate) fn logical_address(interface: Option<String>) -> Result<String, ReadoutError> {
+pub(crate) fn logical_address(interface: Option<&str>) -> Result<String, ReadoutError> {
     if let Some(it) = interface {
         if let Ok(addresses) = if_addrs::get_if_addrs() {
             for iface in addresses {

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -303,7 +303,7 @@ pub(crate) fn get_meminfo_value(value: &str) -> u64 {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub(crate) fn local_ip(interface: Option<String>) -> Result<String, ReadoutError> {
+pub(crate) fn logical_address(interface: Option<String>) -> Result<String, ReadoutError> {
     if let Some(it) = interface {
         if let Ok(addresses) = if_addrs::get_if_addrs() {
             for iface in addresses {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -284,25 +284,25 @@ pub trait NetworkReadout {
 
     /// This function should return the number of bytes
     /// transmitted by the interface of the host.
-    fn tx_bytes(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+    fn tx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 
     /// This function should return the number of packets
     /// transmitted by the interface of the host.
-    fn tx_packets(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+    fn tx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 
     /// This function should return the number of bytes
     /// received by the interface of the host.
-    fn rx_bytes(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+    fn rx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 
     /// This function should return the number of packets
     /// received by the interface of the host.
-    fn rx_packets(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+    fn rx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 
@@ -310,7 +310,7 @@ pub trait NetworkReadout {
     /// specified interface.
     ///
     /// _e.g._ `192.168.1.2`
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 
@@ -318,7 +318,7 @@ pub trait NetworkReadout {
     /// specified interface.
     ///
     /// _e.g._ `52:9a:d2:d3:b5:fd`
-    fn physical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn physical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -256,6 +256,29 @@ pub trait PackageReadout {
     }
 }
 
+
+pub trait NetworkReadout {
+    /// Creates a new instance of the structure which implements this trait.
+    fn new() -> Self;
+
+    /// This function should return the number of installed packages.
+    fn tx_bytes(&self) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
+    fn rx_bytes(&self) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
+    fn rx_packets(&self) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
+    fn tx_packets(&self) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+}
+
 /**
 This trait provides the interface for implementing functionality used for getting _product information_
 about the host machine.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -268,7 +268,7 @@ use libmacchina::traits::ReadoutError;
 
 impl NetworkReadout for MacOSNetworkReadout {
     fn new() -> Self {
-        MacOSPackageReadout {}
+        MacOSNetworkReadout {}
     }
 
     fn logical_address(&self) -> Result<String, ReadoutError> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -266,12 +266,12 @@ This trait provides an interface to various networking statistics about the host
 use libmacchina::traits::NetworkReadout;
 use libmacchina::traits::ReadoutError;
 
-impl PackageReadout for MacOSNetworkReadout {
+impl NetworkReadout for MacOSNetworkReadout {
     fn new() -> Self {
         MacOSPackageReadout {}
     }
 
-    fn local_ip(&self) -> Result<String, ReadoutError> {
+    fn logical_address(&self) -> Result<String, ReadoutError> {
         todo!()
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -266,12 +266,14 @@ This trait provides an interface to various networking statistics about the host
 use libmacchina::traits::NetworkReadout;
 use libmacchina::traits::ReadoutError;
 
+pub struct MacOSNetworkReadout;
+
 impl NetworkReadout for MacOSNetworkReadout {
     fn new() -> Self {
         MacOSNetworkReadout {}
     }
 
-    fn logical_address(&self) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         todo!()
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -41,7 +41,7 @@ impl From<&ReadoutError> for ReadoutError {
 
 lazy_static! {
     static ref STANDARD_NO_IMPL: ReadoutError = ReadoutError::Warning(String::from(
-        "This metric is not available on this platform or is not yet implemented by Macchina."
+        "This metric is not available on this platform or is not yet implemented by macchina."
     ));
 }
 
@@ -158,8 +158,9 @@ pub trait KernelReadout {
 }
 
 /**
-This trait provides common functions for _querying the current memory state_ of the host
-device, most notably `free` and `used`.
+This trait provides common functions for _querying the current memory state_ of the host device,
+most notably `total` and `used`. All other methods exposed by this trait are there in case you're
+intending to calculate memory usage on your own.
 
 # Example
 
@@ -223,7 +224,7 @@ pub trait MemoryReadout {
 }
 
 /**
-This trait provides the interface for implementing functionality used for _counting packages_ on
+This trait provides an interface to various functions used to _count packages_ on
 the host system. Almost all modern operating systems use some kind of package manager.
 
 # Example
@@ -256,25 +257,68 @@ pub trait PackageReadout {
     }
 }
 
+/**
+This trait provides an interface to various networking statistics about the host system.
 
+# Example
+
+```
+use libmacchina::traits::NetworkReadout;
+use libmacchina::traits::ReadoutError;
+
+impl PackageReadout for MacOSNetworkReadout {
+    fn new() -> Self {
+        MacOSPackageReadout {}
+    }
+
+    fn local_ip(&self) -> Result<String, ReadoutError> {
+        todo!()
+    }
+}
+```
+
+*/
 pub trait NetworkReadout {
     /// Creates a new instance of the structure which implements this trait.
     fn new() -> Self;
 
-    /// This function should return the number of installed packages.
-    fn tx_bytes(&self) -> Result<usize, ReadoutError> {
+    /// This function should return the number of bytes
+    /// transmitted by the interface of the host.
+    fn tx_bytes(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 
-    fn rx_bytes(&self) -> Result<usize, ReadoutError> {
+    /// This function should return the number of packets
+    /// transmitted by the interface of the host.
+    fn tx_packets(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 
-    fn rx_packets(&self) -> Result<usize, ReadoutError> {
+    /// This function should return the number of bytes
+    /// received by the interface of the host.
+    fn rx_bytes(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 
-    fn tx_packets(&self) -> Result<usize, ReadoutError> {
+    /// This function should return the number of packets
+    /// received by the interface of the host.
+    fn rx_packets(&self, interface: Option<String>) -> Result<usize, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
+    /// This function should return the logical addess, i.e. _local IPv4/6 address_ of the
+    /// specified interface.
+    ///
+    /// _e.g._ `192.168.1.2`
+    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+        Err(STANDARD_NO_IMPL.clone())
+    }
+
+    /// This function should return the physical address, i.e. _MAC address_ of the
+    /// specified interface.
+    ///
+    /// _e.g._ `52:9a:d2:d3:b5:fd`
+    fn physical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 }
@@ -406,14 +450,6 @@ pub trait GeneralReadout {
     ///
     /// _e.g._ `Arch Linux`
     fn distribution(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
-    }
-
-    /// This function should return the user's local ip address of the
-    /// specified interface.
-    ///
-    /// _e.g._ `192.168.1.11`
-    fn local_ip(&self, interface: Option<String>) -> Result<String, ReadoutError> {
         Err(STANDARD_NO_IMPL.clone())
     }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -346,7 +346,7 @@ impl NetworkReadout for WindowsNetworkReadout {
         WindowsNetworkReadout
     }
 
-    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         match interface {
             Some(it) => {
                 if let Ok(addresses) = local_ip_address::list_afinet_netifas() {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -222,27 +222,6 @@ impl GeneralReadout for WindowsGeneralReadout {
         Ok(str)
     }
 
-    fn local_ip(&self, interface: Option<String>) -> Result<String, ReadoutError> {
-        match interface {
-            Some(it) => {
-                if let Ok(addresses) = local_ip_address::list_afinet_netifas() {
-                    if let Some((_, ip)) = local_ip_address::find_ifa(addresses, &it) {
-                        return Ok(ip.to_string());
-                    }
-                }
-            }
-            None => {
-                if let Ok(local_ip) = local_ip_address::local_ip() {
-                    return Ok(local_ip.to_string());
-                }
-            }
-        };
-
-        Err(ReadoutError::Other(
-            "Unable to get local IP address.".to_string(),
-        ))
-    }
-
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
         let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
         let central_processor =
@@ -356,5 +335,35 @@ impl PackageReadout for WindowsPackageReadout {
 impl WindowsPackageReadout {
     fn count_cargo() -> Option<usize> {
         crate::shared::count_cargo()
+    }
+}
+
+
+pub struct WindowsNetworkReadout;
+
+impl NetworkReadout for WindowsNetworkReadout {
+    fn new() -> Self {
+        WindowsNetworkReadout
+    }
+
+    fn logical_address(&self, interface: Option<String>) -> Result<String, ReadoutError> {
+        match interface {
+            Some(it) => {
+                if let Ok(addresses) = local_ip_address::list_afinet_netifas() {
+                    if let Some((_, ip)) = local_ip_address::find_ifa(addresses, &it) {
+                        return Ok(ip.to_string());
+                    }
+                }
+            }
+            None => {
+                if let Ok(local_ip) = local_ip_address::local_ip() {
+                    return Ok(local_ip.to_string());
+                }
+            }
+        };
+
+        Err(ReadoutError::Other(
+            "Unable to get local IP address.".to_string(),
+        ))
     }
 }


### PR DESCRIPTION
# Breaking Change

Moved the following method:
- `GeneralReadout::local_ip(interface)` to `NetworkReadout::logical_address(interface)`

# New Trait

Added the following new methods:
- `NetworkReadout::physical_address(interface)`
- `NetworkReadout::rx_bytes(interface)`
- `NetworkReadout::tx_bytes(interface)`
- `NetworkReadout::rx_packets(interface)`
- `NetworkReadout::tx_packets(interface)`

The above methods have only been implemented by `LinuxNetworkReadout`.