### PR TITLE
Explicitly mark readouts that are not implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ build = "build.rs"
 [dependencies]
 cfg-if = "1.0.0"
 libc = "0.2.110"
-lazy_static = "1.4.0"
 byte-unit = "4.0.13"
 walkdir = "2.3.2"
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -4,6 +4,7 @@ mod system_properties;
 use crate::extra;
 use crate::shared;
 use crate::traits::*;
+use byte_unit::AdjustedByte;
 use itertools::Itertools;
 use std::ffi::{CStr, CString};
 use std::fs;
@@ -77,6 +78,10 @@ impl BatteryReadout for AndroidBatteryReadout {
             ))),
         }
     }
+
+    fn health(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
 }
 
 impl KernelReadout for AndroidKernelReadout {
@@ -123,6 +128,14 @@ impl GeneralReadout for AndroidGeneralReadout {
         }
     }
 
+    fn backlight(&self) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn resolution(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn machine(&self) -> Result<String, ReadoutError> {
         let product_readout = AndroidProductReadout::new();
 
@@ -156,6 +169,26 @@ impl GeneralReadout for AndroidGeneralReadout {
         } else {
             Ok(unsafe { CStr::from_ptr(__name).to_string_lossy().into_owned() })
         }
+    }
+
+    fn distribution(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn desktop_environment(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn session(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn window_manager(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn terminal(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn shell(&self, format: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError> {
@@ -253,6 +286,14 @@ impl GeneralReadout for AndroidGeneralReadout {
                 "Failed to get system statistics".to_string(),
             ))
         }
+    }
+
+    fn os_name(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 }
 
@@ -429,7 +470,27 @@ impl NetworkReadout for AndroidNetworkReadout {
         AndroidNetworkReadout
     }
 
+    fn tx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn tx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
+    }
+
+    fn physical_address(&self, _: Option<&str>) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 }

--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -79,6 +79,10 @@ impl BatteryReadout for FreeBSDBatteryReadout {
 
         Err(ReadoutError::MetricNotAvailable)
     }
+
+    fn health(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
 }
 
 impl KernelReadout for FreeBSDKernelReadout {
@@ -307,6 +311,18 @@ impl MemoryReadout for FreeBSDMemoryReadout {
             / 1024)
     }
 
+    fn buffers(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn cached(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn reclaimable(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn used(&self) -> Result<u64, ReadoutError> {
         let total = self.total().unwrap();
         let free = self.free().unwrap();
@@ -386,7 +402,27 @@ impl NetworkReadout for FreeBSDNetworkReadout {
         FreeBSDNetworkReadout
     }
 
+    fn tx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn tx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
+    }
+
+    fn physical_address(&self, _: Option<&str>) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 use cfg_if::cfg_if;
 
-#[macro_use]
-extern crate lazy_static;
-
 cfg_if! {
     if #[cfg(all(target_os = "linux", feature = "openwrt"))] {
         mod extra;

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -530,6 +530,10 @@ impl GeneralReadout for LinuxGeneralReadout {
         Ok(version)
     }
 
+    fn os_name(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
         shared::disk_space(String::from("/"))
     }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -86,6 +86,10 @@ impl BatteryReadout for MacOSBatteryReadout {
             "Status property was not present in the dictionary that was returned from IOKit.",
         )))
     }
+
+    fn health(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
 }
 
 impl MacOSIOPMPowerSource {
@@ -204,6 +208,10 @@ impl GeneralReadout for MacOSGeneralReadout {
         }
     }
 
+    fn backlight(&self) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn resolution(&self) -> Result<String, ReadoutError> {
         let displays = CGDisplay::active_displays();
         if let Err(e) = displays {
@@ -266,6 +274,10 @@ impl GeneralReadout for MacOSGeneralReadout {
 
     fn desktop_environment(&self) -> Result<String, ReadoutError> {
         Ok(String::from("Aqua"))
+    }
+
+    fn session(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn window_manager(&self) -> Result<String, ReadoutError> {
@@ -423,6 +435,14 @@ impl MemoryReadout for MacOSMemoryReadout {
         Ok(((free_count * self.page_size as u64) / 1024) as u64)
     }
 
+    fn buffers(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn cached(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn reclaimable(&self) -> Result<u64, ReadoutError> {
         let vm_stats = MacOSMemoryReadout::mach_vm_stats()?;
         Ok((vm_stats.purgeable_count as u64 * self.page_size as u64 / 1024) as u64)
@@ -499,6 +519,10 @@ impl ProductReadout for MacOSProductReadout {
 
     fn vendor(&self) -> Result<String, ReadoutError> {
         Ok(String::from("Apple"))
+    }
+
+    fn family(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn product(&self) -> Result<String, ReadoutError> {
@@ -584,8 +608,28 @@ impl NetworkReadout for MacOSNetworkReadout {
         MacOSNetworkReadout
     }
 
+    fn tx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn tx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
+    }
+
+    fn physical_address(&self, _: Option<&str>) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 }
 

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -82,6 +82,10 @@ impl BatteryReadout for NetBSDBatteryReadout {
 
         Err(ReadoutError::Other("envstat is not installed".to_owned()))
     }
+
+    fn health(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
 }
 
 impl KernelReadout for NetBSDKernelReadout {
@@ -351,6 +355,18 @@ impl MemoryReadout for NetBSDMemoryReadout {
         Ok(shared::get_meminfo_value("MemFree"))
     }
 
+    fn buffers(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn cached(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn reclaimable(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn used(&self) -> Result<u64, ReadoutError> {
         let total = self.total().unwrap();
         let free = self.free().unwrap();
@@ -448,7 +464,27 @@ impl NetworkReadout for NetBSDNetworkReadout {
         NetBSDNetworkReadout
     }
 
+    fn tx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn tx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
+    }
+
+    fn physical_address(&self, _: Option<&str>) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 }

--- a/src/openwrt/mod.rs
+++ b/src/openwrt/mod.rs
@@ -1,6 +1,5 @@
 mod sysinfo_ffi;
 
-use crate::extra;
 use crate::shared;
 use crate::traits::*;
 use byte_unit::AdjustedByte;
@@ -32,6 +31,18 @@ pub struct OpenWrtNetworkReadout;
 impl BatteryReadout for OpenWrtBatteryReadout {
     fn new() -> Self {
         OpenWrtBatteryReadout
+    }
+
+    fn percentage(&self) -> Result<u8, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn status(&self) -> Result<BatteryState, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn health(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 }
 
@@ -66,6 +77,14 @@ impl GeneralReadout for OpenWrtGeneralReadout {
             hostname_ctl: Ctl::new("kernel.hostname").ok(),
             sysinfo: sysinfo::new(),
         }
+    }
+
+    fn backlight(&self) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn resolution(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn machine(&self) -> Result<String, ReadoutError> {
@@ -109,6 +128,22 @@ impl GeneralReadout for OpenWrtGeneralReadout {
         }
 
         Ok(content.name)
+    }
+
+    fn desktop_environment(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn session(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn window_manager(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn terminal(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn shell(&self, format: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError> {
@@ -170,6 +205,10 @@ impl GeneralReadout for OpenWrtGeneralReadout {
                 "sysinfo struct returned an error.",
             )));
         }
+    }
+
+    fn os_name(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
@@ -290,7 +329,27 @@ impl NetworkReadout for OpenWrtNetworkReadout {
         OpenWrtNetworkReadout
     }
 
+    fn tx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn tx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         shared::logical_address(interface)
+    }
+
+    fn physical_address(&self, _: Option<&str>) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,6 +12,9 @@ pub enum ReadoutError {
     /// If you encounter this error, it means that the requested value is not available.
     MetricNotAvailable,
 
+    /// The default error for any readout that is not implemented by a particular platform.
+    NotImplemented,
+
     /// A readout for a metric might be available, but fails due to missing dependencies or other
     /// unsatisfied requirements.
     Other(String),
@@ -27,6 +30,9 @@ impl ToString for ReadoutError {
             ReadoutError::MetricNotAvailable => {
                 String::from("Metric is not available on this system.")
             }
+            ReadoutError::NotImplemented => {
+                String::from("This metric is not available on this platform or is not yet implemented by libmacchina.")
+            }
             ReadoutError::Other(s) => s.clone(),
             ReadoutError::Warning(s) => s.clone(),
         }
@@ -37,12 +43,6 @@ impl From<&ReadoutError> for ReadoutError {
     fn from(r: &ReadoutError) -> Self {
         r.to_owned()
     }
-}
-
-lazy_static! {
-    static ref STANDARD_NO_IMPL: ReadoutError = ReadoutError::Warning(String::from(
-        "This metric is not available on this platform or is not yet implemented by macchina."
-    ));
 }
 
 /**
@@ -85,19 +85,19 @@ pub trait BatteryReadout {
     /// This function is used for querying the current battery percentage. The expected value is
     /// a u8 in the range of `0` to `100`.
     fn percentage(&self) -> Result<u8, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function is used for querying the current battery charging state. If the battery is
     /// currently being charged, we expect a return value of `BatteryState::Charging`, otherwise
     /// `BatteryState::Discharging`.
     fn status(&self) -> Result<BatteryState, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function is used for querying the current battery's health in percentage.
     fn health(&self) -> Result<u64, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 }
 
@@ -136,12 +136,12 @@ pub trait KernelReadout {
 
     /// This function should return the version of the kernel (e. g. `20.3.0` on macOS for Darwin).
     fn os_release(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the kernel name as a string (e. g. `Darwin` on macOS).
     fn os_type(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function is used for getting the kernel name and version in a pretty format.
@@ -194,32 +194,32 @@ pub trait MemoryReadout {
 
     /// This function should return the total available memory in kilobytes.
     fn total(&self) -> Result<u64, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the free available memory in kilobytes.
     fn free(&self) -> Result<u64, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the current memory value for buffers in kilobytes.
     fn buffers(&self) -> Result<u64, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the amount of cached content in memory in kilobytes.
     fn cached(&self) -> Result<u64, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the amount of reclaimable memory in kilobytes.
     fn reclaimable(&self) -> Result<u64, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the amount of currently used memory in kilobytes.
     fn used(&self) -> Result<u64, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 }
 
@@ -287,25 +287,25 @@ pub trait NetworkReadout {
     /// This function should return the number of bytes
     /// transmitted by the interface of the host.
     fn tx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the number of packets
     /// transmitted by the interface of the host.
     fn tx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the number of bytes
     /// received by the interface of the host.
     fn rx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the number of packets
     /// received by the interface of the host.
     fn rx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the logical addess, i.e. _local IPv4/6 address_ of the
@@ -313,7 +313,7 @@ pub trait NetworkReadout {
     ///
     /// _e.g._ `192.168.1.2`
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the physical address, i.e. _MAC address_ of the
@@ -321,7 +321,7 @@ pub trait NetworkReadout {
     ///
     /// _e.g._ `52:9a:d2:d3:b5:fd`
     fn physical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 }
 
@@ -366,7 +366,7 @@ pub trait ProductReadout {
     ///
     /// This is set by the machine's manufacturer.
     fn vendor(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the family name of the host's machine.
@@ -375,7 +375,7 @@ pub trait ProductReadout {
     ///
     /// This is set by the machine's manufacturer.
     fn family(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the product name of the host's machine.
@@ -384,7 +384,7 @@ pub trait ProductReadout {
     ///
     /// This is set by the machine's manufacturer.
     fn product(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 }
 
@@ -424,63 +424,63 @@ pub trait GeneralReadout {
     ///
     /// _e.g._ `100`
     fn backlight(&self) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the display resolution of the machine.
     ///
     /// _e.g. `1920x1080`
     fn resolution(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the username of the currently logged on user.
     ///
     /// _e.g._ `johndoe`
     fn username(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the hostname of the host's computer.
     ///
     /// _e.g._ `supercomputer`
     fn hostname(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the name of the distribution of the operating system.
     ///
     /// _e.g._ `Arch Linux`
     fn distribution(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the name of the used desktop environment.
     ///
     /// _e.g._ `Plasma`
     fn desktop_environment(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the type of session that's in use.
     ///
     /// _e.g._ `Wayland`
     fn session(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the name of the used window manager.
     ///
     /// _e.g._ `KWin`
     fn window_manager(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the name of the used terminal emulator.
     ///
     /// _e.g._ `kitty`
     fn terminal(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /**
@@ -496,55 +496,55 @@ pub trait GeneralReadout {
     */
 
     fn shell(&self, _shorthand: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the model name of the CPU \
     ///
     /// _e.g._ `Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz`
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the average CPU usage over the last minute.
     fn cpu_usage(&self) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the number of physical cores of the host's processor.
     fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the number of logical cores of the host's processor.
     fn cpu_cores(&self) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the uptime of the OS in seconds.
     fn uptime(&self) -> Result<usize, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the name of the physical machine.
     ///
     /// _e.g._ `MacBookPro11,5`
     fn machine(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the name of the OS in a pretty format.
     ///
     /// _e.g._ `macOS 11.2.2 Big Sur`
     fn os_name(&self) -> Result<String, ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 
     /// This function should return the used disk space in a human-readable and desirable format.
     ///
     /// _e.g._ '1.2TB / 2TB'
     fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
-        Err(STANDARD_NO_IMPL.clone())
+        Err(ReadoutError::NotImplemented)
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -75,6 +75,11 @@ impl BatteryReadout for MacOSBatteryReadout {
         //check if battery is being charged...
         Ok(BatteryState::Charging) //always charging.
     }
+
+    fn health(&self) -> Result<u64, ReadoutError>{
+        //check the battery health...
+        Ok(100) //totally healtyh
+    }
 }
 ```
 */
@@ -84,21 +89,15 @@ pub trait BatteryReadout {
 
     /// This function is used for querying the current battery percentage. The expected value is
     /// a u8 in the range of `0` to `100`.
-    fn percentage(&self) -> Result<u8, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn percentage(&self) -> Result<u8, ReadoutError>;
 
     /// This function is used for querying the current battery charging state. If the battery is
     /// currently being charged, we expect a return value of `BatteryState::Charging`, otherwise
     /// `BatteryState::Discharging`.
-    fn status(&self) -> Result<BatteryState, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn status(&self) -> Result<BatteryState, ReadoutError>;
 
     /// This function is used for querying the current battery's health in percentage.
-    fn health(&self) -> Result<u64, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn health(&self) -> Result<u64, ReadoutError>;
 }
 
 /**
@@ -135,14 +134,10 @@ pub trait KernelReadout {
     fn new() -> Self;
 
     /// This function should return the version of the kernel (e. g. `20.3.0` on macOS for Darwin).
-    fn os_release(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn os_release(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the kernel name as a string (e. g. `Darwin` on macOS).
-    fn os_type(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn os_type(&self) -> Result<String, ReadoutError>;
 
     /// This function is used for getting the kernel name and version in a pretty format.
     fn pretty_kernel(&self) -> Result<String, ReadoutError> {
@@ -180,6 +175,26 @@ impl MemoryReadout for MacOSMemoryReadout {
         Ok(512 * 1024) // Return 512mb in kilobytes.
     }
 
+    fn free(&self) -> Result<u64, ReadoutError> {
+        // Get the amount of free memory
+        Ok(256 * 1024) // Return 256mb in kilobytes.
+    }
+
+    fn buffers(&self) -> Result<u64, ReadoutError> {
+        // Get the current memory value for buffers
+        Ok(64 * 1024) // Return 64mb in kilobytes.
+    }
+
+    fn cached(&self) -> Result<u64, ReadoutError> {
+        // Get the amount of cached content in memory
+        Ok(128 * 1024) // Return 128mb in kilobytes.
+    }
+
+    fn reclaimable(&self) -> Result<u64, ReadoutError> {
+        // Get the amount of reclaimable memory
+        Ok(64 * 1024) // Return 64mb in kilobytes.
+    }
+
     fn used(&self) -> Result<u64, ReadoutError> {
         // Get the currently used memory.
         Ok(256 * 1024) // Return 256mb in kilobytes.
@@ -193,34 +208,22 @@ pub trait MemoryReadout {
     fn new() -> Self;
 
     /// This function should return the total available memory in kilobytes.
-    fn total(&self) -> Result<u64, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn total(&self) -> Result<u64, ReadoutError>;
 
     /// This function should return the free available memory in kilobytes.
-    fn free(&self) -> Result<u64, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn free(&self) -> Result<u64, ReadoutError>;
 
     /// This function should return the current memory value for buffers in kilobytes.
-    fn buffers(&self) -> Result<u64, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn buffers(&self) -> Result<u64, ReadoutError>;
 
     /// This function should return the amount of cached content in memory in kilobytes.
-    fn cached(&self) -> Result<u64, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn cached(&self) -> Result<u64, ReadoutError>;
 
     /// This function should return the amount of reclaimable memory in kilobytes.
-    fn reclaimable(&self) -> Result<u64, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn reclaimable(&self) -> Result<u64, ReadoutError>;
 
     /// This function should return the amount of currently used memory in kilobytes.
-    fn used(&self) -> Result<u64, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn used(&self) -> Result<u64, ReadoutError>;
 }
 
 /**
@@ -273,7 +276,27 @@ impl NetworkReadout for MacOSNetworkReadout {
         MacOSNetworkReadout {}
     }
 
+    fn tx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
+        todo!()
+    }
+
+    fn tx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
+        todo!()
+    }
+
+    fn rx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
+        todo!()
+    }
+
+    fn rx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
+        todo!()
+    }
+
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
+        todo!()
+    }
+
+    fn physical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         todo!()
     }
 }
@@ -286,43 +309,31 @@ pub trait NetworkReadout {
 
     /// This function should return the number of bytes
     /// transmitted by the interface of the host.
-    fn tx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn tx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError>;
 
     /// This function should return the number of packets
     /// transmitted by the interface of the host.
-    fn tx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn tx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError>;
 
     /// This function should return the number of bytes
     /// received by the interface of the host.
-    fn rx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn rx_bytes(&self, interface: Option<&str>) -> Result<usize, ReadoutError>;
 
     /// This function should return the number of packets
     /// received by the interface of the host.
-    fn rx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn rx_packets(&self, interface: Option<&str>) -> Result<usize, ReadoutError>;
 
     /// This function should return the logical addess, i.e. _local IPv4/6 address_ of the
     /// specified interface.
     ///
     /// _e.g._ `192.168.1.2`
-    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError>;
 
     /// This function should return the physical address, i.e. _MAC address_ of the
     /// specified interface.
     ///
     /// _e.g._ `52:9a:d2:d3:b5:fd`
-    fn physical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn physical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError>;
 }
 
 /**
@@ -365,27 +376,21 @@ pub trait ProductReadout {
     /// _e.g._ `Lenovo`
     ///
     /// This is set by the machine's manufacturer.
-    fn vendor(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn vendor(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the family name of the host's machine.
     ///
     /// _e.g._ `IdeaPad S540-15IWL GTX`
     ///
     /// This is set by the machine's manufacturer.
-    fn family(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn family(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the product name of the host's machine.
     ///
     /// _e.g._ `81SW`
     ///
     /// This is set by the machine's manufacturer.
-    fn product(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn product(&self) -> Result<String, ReadoutError>;
 }
 
 /**
@@ -395,8 +400,11 @@ information about the running operating system and current user.
 # Example
 
 ```
+use byte_unit::{AdjustedByte, Byte};
 use libmacchina::traits::GeneralReadout;
 use libmacchina::traits::ReadoutError;
+use libmacchina::traits::ShellFormat;
+use libmacchina::traits::ShellKind;
 
 pub struct MacOSGeneralReadout;
 
@@ -406,12 +414,80 @@ impl GeneralReadout for MacOSGeneralReadout {
         MacOSGeneralReadout {}
     }
 
+    fn backlight(&self) -> Result<usize, ReadoutError> {
+        Ok(100) //full brightness
+    }
+
+    fn resolution(&self) -> Result<String, ReadoutError> {
+        Ok("1920x1080".to_string())
+    }
+
     fn username(&self) -> Result<String, ReadoutError> {
         //let username = NSUserName();
         Ok(String::from("johndoe"))
     }
 
-    // Implement other trait functions...
+    fn hostname(&self) -> Result<String, ReadoutError> {
+        Ok("supercomputer".to_string())
+    }
+
+    fn distribution(&self) -> Result<String, ReadoutError> {
+        Ok("Arch Linux".to_string())
+    }
+
+    fn desktop_environment(&self) -> Result<String, ReadoutError> {
+        Ok("Plasma".to_string())
+    }
+
+    fn session(&self) -> Result<String, ReadoutError> {
+        Ok("Wayland".to_string())
+    }
+
+    fn window_manager(&self) -> Result<String, ReadoutError> {
+        Ok("KWin".to_string())
+    }
+
+    fn terminal(&self) -> Result<String, ReadoutError> {
+        Ok("kitty".to_string())
+    }
+
+    fn shell(&self, _shorthand: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError> {
+        Ok("bash".to_string())
+    }
+
+    fn cpu_model_name(&self) -> Result<String, ReadoutError> {
+        Ok("Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz".to_string())
+    }
+
+    fn cpu_usage(&self) -> Result<usize, ReadoutError> {
+        Ok(20) //20% CPU usage
+    }
+
+    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
+        Ok(4)
+    }
+
+    fn cpu_cores(&self) -> Result<usize, ReadoutError> {
+        Ok(8)
+    }
+
+    fn uptime(&self) -> Result<usize, ReadoutError> {
+        Ok(24 * 60 * 60) //1 day
+    }
+
+    fn machine(&self) -> Result<String, ReadoutError> {
+        Ok("MacBookPro11,5".to_string())
+    }
+
+    fn os_name(&self) -> Result<String, ReadoutError> {
+        Ok("macOS 11.2.2 Big Sur".to_string())
+    }
+
+    fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
+        let used_bytes = Byte::from_str("1.2TB").unwrap().get_appropriate_unit(true);
+        let total_bytes = Byte::from_str("2TB").unwrap().get_appropriate_unit(true);
+        Ok((used_bytes, total_bytes))
+    }
 }
 
 ```
@@ -423,65 +499,47 @@ pub trait GeneralReadout {
     /// This function should return the backlight (brightness) value of the machine.
     ///
     /// _e.g._ `100`
-    fn backlight(&self) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn backlight(&self) -> Result<usize, ReadoutError>;
 
     /// This function should return the display resolution of the machine.
     ///
     /// _e.g. `1920x1080`
-    fn resolution(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn resolution(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the username of the currently logged on user.
     ///
     /// _e.g._ `johndoe`
-    fn username(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn username(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the hostname of the host's computer.
     ///
     /// _e.g._ `supercomputer`
-    fn hostname(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn hostname(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the name of the distribution of the operating system.
     ///
     /// _e.g._ `Arch Linux`
-    fn distribution(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn distribution(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the name of the used desktop environment.
     ///
     /// _e.g._ `Plasma`
-    fn desktop_environment(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn desktop_environment(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the type of session that's in use.
     ///
     /// _e.g._ `Wayland`
-    fn session(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn session(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the name of the used window manager.
     ///
     /// _e.g._ `KWin`
-    fn window_manager(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn window_manager(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the name of the used terminal emulator.
     ///
     /// _e.g._ `kitty`
-    fn terminal(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn terminal(&self) -> Result<String, ReadoutError>;
 
     /**
     This function should return the currently running shell depending on the `_shorthand` value.
@@ -495,57 +553,39 @@ pub trait GeneralReadout {
     _e.g._ /bin/bash, /bin/zsh, etc.
     */
 
-    fn shell(&self, _shorthand: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn shell(&self, _shorthand: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError>;
 
     /// This function should return the model name of the CPU \
     ///
     /// _e.g._ `Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz`
-    fn cpu_model_name(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn cpu_model_name(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the average CPU usage over the last minute.
-    fn cpu_usage(&self) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn cpu_usage(&self) -> Result<usize, ReadoutError>;
 
     /// This function should return the number of physical cores of the host's processor.
-    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError>;
 
     /// This function should return the number of logical cores of the host's processor.
-    fn cpu_cores(&self) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn cpu_cores(&self) -> Result<usize, ReadoutError>;
 
     /// This function should return the uptime of the OS in seconds.
-    fn uptime(&self) -> Result<usize, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn uptime(&self) -> Result<usize, ReadoutError>;
 
     /// This function should return the name of the physical machine.
     ///
     /// _e.g._ `MacBookPro11,5`
-    fn machine(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn machine(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the name of the OS in a pretty format.
     ///
     /// _e.g._ `macOS 11.2.2 Big Sur`
-    fn os_name(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn os_name(&self) -> Result<String, ReadoutError>;
 
     /// This function should return the used disk space in a human-readable and desirable format.
     ///
     /// _e.g._ '1.2TB / 2TB'
-    fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError> {
-        Err(ReadoutError::NotImplemented)
-    }
+    fn disk_space(&self) -> Result<(AdjustedByte, AdjustedByte), ReadoutError>;
 }
 
 /// Holds the possible variants for battery status.

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -52,6 +52,10 @@ impl BatteryReadout for WindowsBatteryReadout {
             ))),
         };
     }
+
+    fn health(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
 }
 
 impl WindowsBatteryReadout {
@@ -106,6 +110,22 @@ impl MemoryReadout for WindowsMemoryReadout {
         Ok(memory_status.ullTotalPhys / 1024u64)
     }
 
+    fn free(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn buffers(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn cached(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn reclaimable(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn used(&self) -> Result<u64, ReadoutError> {
         let memory_status = WindowsMemoryReadout::get_memory_status()?;
         Ok((memory_status.ullTotalPhys - memory_status.ullAvailPhys) / 1024u64)
@@ -134,6 +154,14 @@ pub struct WindowsGeneralReadout;
 impl GeneralReadout for WindowsGeneralReadout {
     fn new() -> Self {
         WindowsGeneralReadout
+    }
+
+    fn backlight(&self) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn resolution(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn username(&self) -> Result<String, ReadoutError> {
@@ -221,6 +249,30 @@ impl GeneralReadout for WindowsGeneralReadout {
         Ok(str)
     }
 
+    fn distribution(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn desktop_environment(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn session(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn window_manager(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn terminal(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn shell(&self, _shorthand: ShellFormat, _: ShellKind) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
         let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
         let central_processor =
@@ -229,6 +281,18 @@ impl GeneralReadout for WindowsGeneralReadout {
         let processor_name: String = central_processor.get_value("ProcessorNameString")?;
 
         Ok(processor_name)
+    }
+
+    fn cpu_usage(&self) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn cpu_physical_cores(&self) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn cpu_cores(&self) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn uptime(&self) -> Result<usize, ReadoutError> {
@@ -267,6 +331,12 @@ impl GeneralReadout for WindowsGeneralReadout {
                 .to_string(),
         ))
     }
+
+    fn disk_space(
+        &self,
+    ) -> Result<(byte_unit::AdjustedByte, byte_unit::AdjustedByte), ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
 }
 
 pub struct WindowsProductReadout {
@@ -296,6 +366,10 @@ impl ProductReadout for WindowsProductReadout {
                     .to_string(),
             )),
         }
+    }
+
+    fn family(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 
     fn product(&self) -> Result<String, ReadoutError> {
@@ -337,6 +411,22 @@ impl NetworkReadout for WindowsNetworkReadout {
         WindowsNetworkReadout
     }
 
+    fn tx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn tx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_bytes(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
+    fn rx_packets(&self, _: Option<&str>) -> Result<usize, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
+    }
+
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         match interface {
             Some(it) => {
@@ -356,5 +446,9 @@ impl NetworkReadout for WindowsNetworkReadout {
         Err(ReadoutError::Other(
             "Unable to get local IP address.".to_string(),
         ))
+    }
+
+    fn physical_address(&self, _: Option<&str>) -> Result<String, ReadoutError> {
+        Err(ReadoutError::NotImplemented)
     }
 }


### PR DESCRIPTION
This is probably a controversial change. The idea behind this is to make it more obvious, which readouts/functions are supported in the corresponding targets.

**Advantage:** It is easier to determine which functions are implemented for a specific target and what might need to be added in the future.

**Disadvantage:** It might seem messier to have all those `ReadoutError::NotImplemented`.

---
❗ **Important:** I did not yet make the change in the entire library and it therefore does not compile yet. I want to gather some feedback if this is even something that would be accepted, before I finish this work.