### PR TITLE
Fix the readout of cargo packages on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ cfg-if = "1.0.0"
 libc = "0.2.110"
 byte-unit = "4.0.13"
 walkdir = "2.3.2"
+home = "0.5.3"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 if-addrs = "0.6.7"

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -328,21 +328,10 @@ pub(crate) fn logical_address(interface: Option<&str>) -> Result<String, Readout
 }
 
 pub(crate) fn count_cargo() -> Option<usize> {
-    if let Ok(cargo_home) = std::env::var("CARGO_HOME") {
-        let bin = PathBuf::from(cargo_home).join("bin");
-        if bin.exists() {
-            if let Ok(read_dir) = read_dir(bin) {
-                return Some(read_dir.count());
-            }
-        }
-    }
-
-    if let Ok(home) = std::env::var("HOME") {
-        let bin = PathBuf::from(home).join(".cargo").join("bin");
-        if bin.exists() {
-            if let Ok(read_dir) = read_dir(bin) {
-                return Some(read_dir.count());
-            }
+    if let Ok(cargo_home) = home::cargo_home() {
+        let bin = cargo_home.join("bin");
+        if let Ok(read_dir) = read_dir(bin) {
+            return Some(read_dir.count());
         }
     }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -394,7 +394,11 @@ impl PackageReadout for WindowsPackageReadout {
     /// Returns the __number of installed packages__ for the following package managers:
     /// - cargo
     fn count_pkgs(&self) -> Vec<(PackageManager, usize)> {
-        Vec::new()
+        let mut packages = Vec::new();
+        if let Some(c) = WindowsPackageReadout::count_cargo() {
+            packages.push((PackageManager::Cargo, c));
+        }
+        packages
     }
 }
 


### PR DESCRIPTION
The implementation for fetching cargo packages in the `shared` folder works perfectly fine under Windows.
The only reason, why it was not working before was the usage of the `which` function that doesn't work correctly under Windows.