### PR TITLE
Fix build warnings

### DIFF
--- a/src/extra.rs
+++ b/src/extra.rs
@@ -1,5 +1,7 @@
 //! This module provides additional functionalities
 
+#![allow(dead_code)]
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
I am not so sure about the `#![allow(dead_code)]` or if we should find a better solution for the `extra` module.