### PR TITLE
Count installed Scoop packages if available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ num_cpus = "1.13.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 local-ip-address = "0.4.4"
+which = "4.2.2"
 winreg = "0.10.1"
 windows = { version = "0.28.0", features = [
     "Win32_Foundation",

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -637,6 +637,7 @@ pub enum PackageManager {
     Snap,
     Android,
     Pkg,
+    Scoop,
 }
 
 impl ToString for PackageManager {
@@ -658,6 +659,7 @@ impl ToString for PackageManager {
             PackageManager::Snap => "snap",
             PackageManager::Android => "Android",
             PackageManager::Pkg => "pkg",
+            PackageManager::Scoop => "Scoop",
         })
     }
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -398,6 +398,9 @@ impl PackageReadout for WindowsPackageReadout {
         if let Some(c) = WindowsPackageReadout::count_cargo() {
             packages.push((PackageManager::Cargo, c));
         }
+        if let Some(c) = WindowsPackageReadout::count_scoop() {
+            packages.push((PackageManager::Scoop, c));
+        }
         packages
     }
 }
@@ -405,6 +408,16 @@ impl PackageReadout for WindowsPackageReadout {
 impl WindowsPackageReadout {
     fn count_cargo() -> Option<usize> {
         crate::shared::count_cargo()
+    }
+
+    fn count_scoop() -> Option<usize> {
+        if let Ok(path) = which::which("scoop") {
+            if let Ok(dir) = path.join("../../apps").read_dir() {
+                return Some(dir.count() - 1); // One entry belongs to scoop itself
+            }
+        }
+
+        None
     }
 }
 


### PR DESCRIPTION
This change adds support for the [Scoop](https://scoop.sh/) installer on Windows.

It works by querying the `scoop export` command that lists all the installed packages and we can count the number of lines.