### PR TITLE
Improve Scoop package count performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ num_cpus = "1.13.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 local-ip-address = "0.4.4"
-which = "4.2.2"
 winreg = "0.10.1"
 windows = { version = "0.29.0", features = [
     "Win32_Foundation",

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,5 +1,6 @@
 use crate::traits::*;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use winreg::enums::*;
 use winreg::RegKey;
 use wmi::{COMLibrary, Variant, WMIConnection};
@@ -411,13 +412,14 @@ impl WindowsPackageReadout {
     }
 
     fn count_scoop() -> Option<usize> {
-        if let Ok(path) = which::which("scoop") {
-            if let Ok(dir) = path.join("../../apps").read_dir() {
-                return Some(dir.count() - 1); // One entry belongs to scoop itself
-            }
+        let scoop = match std::env::var("SCOOP") {
+            Ok(scoop_var) => PathBuf::from(scoop_var),
+            _ => home::home_dir().unwrap().join("scoop"),
+        };
+        match scoop.join("apps").read_dir() {
+            Ok(dir) => Some(dir.count() - 1), // One entry belongs to scoop itself
+            _ => None,
         }
-
-        None
     }
 }
 


### PR DESCRIPTION
As discussed in #107 I refactored the Scoop package count by using the `SCOOP` environment variable if available, or the default path `C:\Users\<user>\scoop`.

I am happy to say that this improved performance:
| Note | Mean [ms] | Min [ms] | Max [ms] |
|---|---:|---:|---:|
| Before this PR | 54.5 ± 7.6 | 50.6 | 104.5 |
| PR without Scoop installed | 43.0 ± 0.9 | 39.9 | 45.1 |
| PR with Scoop installed | 43.5 ± 0.9 | 41.5 | 46.3 |