### PR TITLE
Code format check during CI build

### DIFF
--- a/.github/workflows/libmacchina.yml
+++ b/.github/workflows/libmacchina.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
+          args: -- --check
           use-cross: ${{ matrix.cross }}
         continue-on-error: false
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -436,7 +436,7 @@ impl AndroidPackageReadout {
         };
 
         let dpkg_dir = Path::new(&prefix).join("var/lib/dpkg/info");
-        
+
         extra::get_entries(&dpkg_dir).map(|entries| {
             entries
                 .iter()

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -332,9 +332,7 @@ impl GeneralReadout for WindowsGeneralReadout {
         ))
     }
 
-    fn disk_space(
-        &self,
-    ) -> Result<(u128, u128), ReadoutError> {
+    fn disk_space(&self) -> Result<(u128, u128), ReadoutError> {
         Err(ReadoutError::NotImplemented)
     }
 }


### PR DESCRIPTION
I noticed that during the CI build we execute `cargo fmt` which applies the code format to all files. However since those changes will not be committed in any way, it is not ensured that no code format violations are introduced.

This PR uses the more appropriate `cargo fmt -- --check` command that fails if the code format is not valid.