### PR TITLE
Mac: Add backlight readout

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,8 @@ fn commit_hash() {
 fn build_macos() {
     println!("cargo:rustc-link-lib=framework=Foundation");
     println!("cargo:rustc-link-lib=framework=IOKit");
+    println!("cargo:rustc-link-search=framework=/System/Library/PrivateFrameworks");
+    println!("cargo:rustc-link-lib=framework=DisplayServices");
 }
 
 fn main() {

--- a/src/macos/mach_ffi.rs
+++ b/src/macos/mach_ffi.rs
@@ -13,6 +13,7 @@ use core_foundation::dictionary::{CFDictionaryRef, CFMutableDictionaryRef};
 use core_foundation::string::CFStringRef;
 use libc::c_char;
 use std::os::raw::c_uint;
+use core_graphics::display::CGDirectDisplayID;
 
 type host_flavor_t = integer_t;
 type host_info64_t = *mut integer_t;
@@ -78,4 +79,6 @@ extern "C" {
     ) -> kern_return_t;
 
     pub fn IOObjectRelease(object: io_object_t) -> kern_return_t;
+
+    pub fn DisplayServicesGetBrightness(id: CGDirectDisplayID, brightness: *mut f32) -> i32;
 }

--- a/src/macos/mach_ffi.rs
+++ b/src/macos/mach_ffi.rs
@@ -11,9 +11,9 @@ use core_foundation::array::CFArrayRef;
 use core_foundation::base::{mach_port_t, CFAllocatorRef, CFRelease, CFTypeRef, TCFTypeRef};
 use core_foundation::dictionary::{CFDictionaryRef, CFMutableDictionaryRef};
 use core_foundation::string::CFStringRef;
+use core_graphics::display::CGDirectDisplayID;
 use libc::c_char;
 use std::os::raw::c_uint;
-use core_graphics::display::CGDirectDisplayID;
 
 type host_flavor_t = integer_t;
 type host_info64_t = *mut integer_t;

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,5 +1,5 @@
 use crate::extra;
-use crate::macos::mach_ffi::{DisplayServicesGetBrightness, io_registry_entry_t, IOObjectRelease};
+use crate::macos::mach_ffi::{io_registry_entry_t, DisplayServicesGetBrightness, IOObjectRelease};
 use crate::macos::mach_ffi::{
     kIOMasterPortDefault, vm_statistics64, IORegistryEntryCreateCFProperties,
     IOServiceGetMatchingService, IOServiceMatching,
@@ -111,14 +111,14 @@ impl MacOSIOPMPowerSource {
 
         unsafe {
             if let Some(battery_installed) =
-            power_source_dict.find(&CFString::new("BatteryInstalled").to_void())
+                power_source_dict.find(&CFString::new("BatteryInstalled").to_void())
             {
                 let number = CFNumber::wrap_under_get_rule((*battery_installed) as CFNumberRef);
                 instance.battery_installed = Some(number.to_i32() != Some(0));
             }
 
             if let Some(state_of_charge) =
-            battery_data_dict.find(&CFString::new("StateOfCharge").to_void())
+                battery_data_dict.find(&CFString::new("StateOfCharge").to_void())
             {
                 let number = CFNumber::wrap_under_get_rule((*state_of_charge) as CFNumberRef);
                 instance.state_of_charge = Some(number.to_i32().unwrap() as usize);
@@ -212,14 +212,16 @@ impl GeneralReadout for MacOSGeneralReadout {
         let main_display = unsafe { CGMainDisplayID() };
         let mut display_brightness: f32 = 0.0;
 
-        let return_value = unsafe {
-            DisplayServicesGetBrightness(main_display, &mut display_brightness)
-        };
+        let return_value =
+            unsafe { DisplayServicesGetBrightness(main_display, &mut display_brightness) };
 
-        if return_value == 0 { Ok((display_brightness * 100.0) as usize) } else {
-            Err(ReadoutError::Other
-                (format!("Could not query display brightness of main display, got return code {}",
-                         return_value)))
+        if return_value == 0 {
+            Ok((display_brightness * 100.0) as usize)
+        } else {
+            Err(ReadoutError::Other(format!(
+                "Could not query display brightness of main display, got return code {}",
+                return_value
+            )))
         }
     }
 


### PR DESCRIPTION
Adds the macOS backlight readout implementation. Works on my M1 Macbook.