### PR TITLE
fix portage package count

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -758,7 +758,13 @@ impl LinuxPackageReadout {
     fn count_portage() -> Option<usize> {
         let pkg_dir = Path::new("/var/db/pkg");
         if pkg_dir.exists() {
-            return Some(walkdir::WalkDir::new(pkg_dir).into_iter().count());
+            return Some(
+                walkdir::WalkDir::new(pkg_dir)
+                    .min_depth(2)
+                    .max_depth(2)
+                    .into_iter()
+                    .count(),
+            );
         }
 
         None


### PR DESCRIPTION
To get an accurate count of portage packages only count the amount of 2 level deep directories. First level are package categories and he third are per package metadata and thus both shouldn't be counted.