### PR TITLE
Use `MemAvailable` meminfo_value to calculate used memory

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -604,11 +604,16 @@ impl MemoryReadout for LinuxMemoryReadout {
 
     fn used(&self) -> Result<u64, ReadoutError> {
         let total = self.total().unwrap();
-        let free = self.free().unwrap();
-        let cached = self.cached().unwrap();
-        let reclaimable = self.reclaimable().unwrap();
-        let buffers = self.buffers().unwrap();
-        Ok(total - free - cached - reclaimable - buffers)
+        match shared::get_meminfo_value("MemAvailable") {
+            0 => {
+                let free = self.free().unwrap();
+                let cached = self.cached().unwrap();
+                let reclaimable = self.reclaimable().unwrap();
+                let buffers = self.buffers().unwrap();
+                Ok(total - free - cached - reclaimable - buffers)
+            }
+            available => Ok(total - available),
+        }
     }
 }
 


### PR DESCRIPTION
This makes the value consistent with other tools and libraries such as the pfetch fetch utility and sysinfo rust crate