### PR TITLE
Add FreeBSD uptime detection with `libc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,6 @@ core-graphics = "0.22.3"
 core-video-sys = "0.1.4"
 mach = "0.3.2"
 
-[target.'cfg(target_os = "freebsd")'.dependencies]
-libc = "0.2.139"
-
 [target.'cfg(target_family = "unix")'.dependencies]
 num_cpus = "1.13.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ core-graphics = "0.22.3"
 core-video-sys = "0.1.4"
 mach = "0.3.2"
 
+[target.'cfg(target_os = "freebsd")'.dependencies]
+libc = "0.2.139"
+
 [target.'cfg(target_family = "unix")'.dependencies]
 num_cpus = "1.13.1"
 

--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -39,11 +39,6 @@ pub struct FreeBSDProductReadout;
 pub struct FreeBSDPackageReadout;
 pub struct FreeBSDNetworkReadout;
 
-struct BootTime {
-    sec: libc::c_ulong,
-    _usec: libc::c_ulong,
-}
-
 impl BatteryReadout for FreeBSDBatteryReadout {
     fn new() -> Self {
         FreeBSDBatteryReadout {
@@ -271,7 +266,7 @@ impl GeneralReadout for FreeBSDGeneralReadout {
                 ));
             }
         };
-        let boot_time = match ctl.value_as::<BootTime>() {
+        let boot_time = match ctl.value_as::<libc::timeval>() {
             Ok(boot_time) => boot_time,
             Err(_) => {
                 return Err(ReadoutError::Other(
@@ -281,7 +276,7 @@ impl GeneralReadout for FreeBSDGeneralReadout {
         };
 
         match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
-            Ok(unix_epoch) => Ok(unix_epoch.as_secs() as usize - boot_time.sec as usize),
+            Ok(unix_epoch) => Ok(unix_epoch.as_secs() as usize - boot_time.tv_sec as usize),
             Err(_) => Err(ReadoutError::MetricNotAvailable),
         }
     }


### PR DESCRIPTION
This is for the most part the implementation from `sysinfo` that uses the `libc` crate to make the `CTL_KERN` and `KERN_BOOTTIME` syscalls. Taking this code snippet should not be an issue as `sysinfo` is licensed under the same license as this project.