### PR TITLE
Implement Android `os_name()` detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,6 @@ windows = { version = "0.39.0", features = [
       "Win32_System_WindowsProgramming"
 ]}
 
-[target.'cfg(target_os = "android")'.dependencies]
-android-properties = "0.2.2"
-
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 if-addrs = "0.6.7"
 

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -282,7 +282,7 @@ impl GeneralReadout for AndroidGeneralReadout {
     }
 
     fn os_name(&self) -> Result<String, ReadoutError> {
-        match android_properties::getprop("ro.build.version.release").value() {
+        match getprop("ro.build.version.release") {
             Some(version) => Ok("Android ".to_string() + &version),
             None => Err(ReadoutError::Other(
                 "Failed to get Android version".to_string(),


### PR DESCRIPTION
This implementation queries the Android `ro.build.version.release` property by using the [android-properties](https://crates.io/crates/android-properties) crate