### PR TITLE
Fix lint warnings

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -148,7 +148,6 @@ impl GeneralReadout for AndroidGeneralReadout {
         if product.is_empty() || product.len() <= 15 {
             return Ok(new_product
                 .split_whitespace()
-                .into_iter()
                 .unique()
                 .join(" "));
         }
@@ -220,7 +219,7 @@ impl GeneralReadout for AndroidGeneralReadout {
 
         if let Ok(content) = file {
             let reader = BufReader::new(content);
-            for line in reader.lines().into_iter().flatten() {
+            for line in reader.lines().flatten() {
                 if line.starts_with("Hardware") {
                     hardware = Some(get_value_from_line(line, "Hardware"));
                     break; // If "Hardware" information is present, the rest is not needed.
@@ -435,7 +434,6 @@ impl AndroidPackageReadout {
             entries
                 .iter()
                 .filter(|x| extra::path_extension(x).unwrap_or_default() == "list")
-                .into_iter()
                 .count()
         })
     }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -532,7 +532,6 @@ impl GeneralReadout for LinuxGeneralReadout {
         } else if version.is_empty() || version.len() <= 22 {
             return Ok(new_product
                 .split_whitespace()
-                .into_iter()
                 .unique()
                 .join(" "));
         }
@@ -784,7 +783,6 @@ impl LinuxPackageReadout {
             entries
                 .iter()
                 .filter(|x| extra::path_extension(x).unwrap_or_default() == "list")
-                .into_iter()
                 .count()
         })
     }
@@ -893,7 +891,6 @@ impl LinuxPackageReadout {
                 entries
                     .iter()
                     .filter(|&x| path_extension(x).unwrap_or_default() == "snap")
-                    .into_iter()
                     .count(),
             );
         }

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -172,7 +172,6 @@ impl GeneralReadout for NetBSDGeneralReadout {
 
         Ok(new_product
             .split_whitespace()
-            .into_iter()
             .unique()
             .join(" "))
     }


### PR DESCRIPTION
I removed the unnecessary `into_iter()` calls to fix the clippy warnings