### PR TITLE
Use a singleton for `COMLibrary` to fix issue #139

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num_cpus = "1.13.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 local-ip-address = "0.4.4"
-wmi = "0.11.0"
+wmi = "0.12.0"
 winreg = "0.10.1"
 windows = { version = "0.39.0", features = [
       "Win32_Foundation",


### PR DESCRIPTION
The `COMLibrary` can not be created more than once (see ohadravid/wmi-rs#37).
Therefore, let's store the resulting `WMIConnection` as a singleton which would also improve performance, since the WMI connection needs to be created only once.

Additionally, I bumped the version of the `wmi` crate.