### PR TITLE
Windows: Implement `free` in `MemoryReadout`

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -110,7 +110,14 @@ impl MemoryReadout for WindowsMemoryReadout {
     }
 
     fn free(&self) -> Result<u64, ReadoutError> {
-        Err(ReadoutError::NotImplemented)
+        // Subtract used memory from total memory
+        match self.total() {
+            Ok(total) => match self.used() {
+                Ok(used) => Ok(total - used),
+                Err(e) => Err(e),
+            },
+            Err(e) => Err(e),
+        }
     }
 
     fn buffers(&self) -> Result<u64, ReadoutError> {


### PR DESCRIPTION
- Using the existing functions, the used memory is subtracted from the total, getting the amount of free memory