### PR TITLE
Windows: Implement `resolution`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,9 @@ windows = { version = "0.39.0", features = [
       "Win32_Foundation",
       "Win32_System_Power",
       "Win32_System_SystemInformation",
-      "Win32_System_WindowsProgramming"
+      "Win32_System_WindowsProgramming",
+      "Win32_Graphics_Gdi",
+      "Win32_UI_HiDpi"
 ]}
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]


### PR DESCRIPTION
Hello, I'm a contributor to https://github.com/lptstr/winfetch (you've talked to the maintainer in #112), and would like to start applying some of the experience I gained there to this project.

- Uses a combination of my implementation in https://github.com/lptstr/winfetch/pull/156/ and [https://patriksvensson.se/posts/2020/06/enumerating-monitors-in-rust-using-win32-api](this one)
  - `SetProcessDpiAwareness` tells the OS to give the program the "real" resolution of each monitor instead of the scaled resolution
  - Uses `EnumDisplayMonitors` to get the information of each monitor
    - Uses a callback function to get the information on each monitor using `GetMonitorInfoW` and store the result in a vector