### PR TITLE
Fix FreeBSD KernelReadout

### DIFF
--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -88,8 +88,8 @@ impl BatteryReadout for FreeBSDBatteryReadout {
 impl KernelReadout for FreeBSDKernelReadout {
     fn new() -> Self {
         FreeBSDKernelReadout {
-            os_release_ctl: Ctl::new("kernel.osrelease").ok(),
-            os_type_ctl: Ctl::new("kernel.ostype").ok(),
+            os_release_ctl: Ctl::new("kern.osrelease").ok(),
+            os_type_ctl: Ctl::new("kern.ostype").ok(),
         }
     }
 


### PR DESCRIPTION
The two syscalls used in the FreeBSD KernelReadout had wrong names, it needs to be `kern.val` instead of `kernel.val`

Tested on FreeBSD 13.1, but is also true for older versions