### PR TITLE
Add nix package count

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -912,15 +912,14 @@ impl LinuxPackageReadout {
     /// that have `snap` installed.
     fn count_snap() -> Option<usize> {
         let snap_dir = Path::new("/var/lib/snapd/snaps");
-        if let Some(entries) = get_entries(snap_dir) {
-            return Some(
-                entries
-                    .iter()
-                    .filter(|&x| path_extension(x).unwrap_or_default() == "snap")
-                    .count(),
-            );
-        }
+        get_entries(snap_dir).map(|entries| {
+            entries
+                .iter()
+                .filter(|&x| path_extension(x).unwrap_or_default() == "snap")
+                .count()
+        })
+    }
 
-        None
+
     }
 }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -726,6 +726,10 @@ impl PackageReadout for LinuxPackageReadout {
             packages.push((PackageManager::Homebrew, c));
         }
 
+        if let Some(c) = LinuxPackageReadout::count_nix() {
+            packages.push((PackageManager::Nix, c))
+        }
+
         packages
     }
 }
@@ -920,6 +924,16 @@ impl LinuxPackageReadout {
         })
     }
 
-
+    /// Returns the number of installed packages for systems
+    /// that have `nix` installed.
+    fn count_nix() -> Option<usize> {
+        let nix_dir = Path::new("/nix/store");
+        let re = Regex::new(r".*-.*\d").unwrap();
+        get_entries(nix_dir).map(|entries| {
+            entries
+                .iter()
+                .filter(|entry| entry.is_dir() && re.is_match(entry.to_str().unwrap_or_default()))
+                .count()
+        })
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -654,6 +654,7 @@ pub enum PackageManager {
     Android,
     Pkg,
     Scoop,
+    Nix,
 }
 
 impl ToString for PackageManager {
@@ -676,6 +677,7 @@ impl ToString for PackageManager {
             PackageManager::Android => "Android",
             PackageManager::Pkg => "pkg",
             PackageManager::Scoop => "Scoop",
+            PackageManager::Nix => "nix",
         })
     }
 }


### PR DESCRIPTION
closes #120

This PR adds nix package count. It works by counting the amount of directories in `/nix/store/` and filtering out the ones that don't have a version number in their package name. This value differs from running `nix-store -q --requisites /run/current-system/sw | wc -l` and `nix-store -q --requisites ~/.nix-profile | wc -l` and adding the values (method used by other fetch utilities) because the directory also contains packages that are not counted by `nix-store -q`.
However, spawning the commands is not an option as they both take around .3s to execute which is way longer than all other readouts combined take to run. This is the best alternative I could find.

To get an idea of how much they differ, here are some numbers:

|System|Method|Amount|
|:-:|:-:|:-:|
|non-NixOS|`nix-store -q ...`|14|
||libmacchina|56|
|NixOS|`nix-store -q ...`|936|
||libmacchina|1235|

I also simplified the `count_snap` function by replacing the `if let ... return` with `map()`