### PR TITLE
Replace mach with mach2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ regex = "1.6.0"
 core-foundation = "0.9.3"
 core-graphics = "0.22.3"
 core-video-sys = "0.1.4"
-mach = "0.3.2"
+mach2 = "0.4.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 num_cpus = "1.13.1"

--- a/src/macos/mach_ffi.rs
+++ b/src/macos/mach_ffi.rs
@@ -1,11 +1,11 @@
 #![allow(non_camel_case_types, non_upper_case_globals, dead_code, unused)]
 
-use mach::boolean;
-use mach::kern_return;
-use mach::kern_return::kern_return_t;
-use mach::mach_types::{host_name_port_t, host_t};
-use mach::message::mach_msg_type_number_t;
-use mach::vm_types::{integer_t, natural_t};
+use mach2::boolean;
+use mach2::kern_return;
+use mach2::kern_return::kern_return_t;
+use mach2::mach_types::{host_name_port_t, host_t};
+use mach2::message::mach_msg_type_number_t;
+use mach2::vm_types::{integer_t, natural_t};
 
 use core_foundation::array::CFArrayRef;
 use core_foundation::base::{mach_port_t, CFAllocatorRef, CFRelease, CFTypeRef, TCFTypeRef};

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -17,7 +17,7 @@ use core_video_sys::{
     kCVTimeIsIndefinite, CVDisplayLinkCreateWithCGDisplay,
     CVDisplayLinkGetNominalOutputVideoRefreshPeriod, CVDisplayLinkRef, CVDisplayLinkRelease,
 };
-use mach::kern_return::KERN_SUCCESS;
+use mach2::kern_return::KERN_SUCCESS;
 use std::ffi::CString;
 use std::fs::DirEntry;
 use std::path::Path;
@@ -493,9 +493,9 @@ impl MemoryReadout for MacOSMemoryReadout {
 
 impl MacOSMemoryReadout {
     fn mach_vm_stats() -> Result<vm_statistics64, ReadoutError> {
-        use mach::kern_return::KERN_SUCCESS;
-        use mach::message::mach_msg_type_number_t;
-        use mach::vm_types::integer_t;
+        use mach2::kern_return::KERN_SUCCESS;
+        use mach2::message::mach_msg_type_number_t;
+        use mach2::vm_types::integer_t;
         use mach_ffi::*;
 
         const HOST_VM_INFO_COUNT: mach_msg_type_number_t =


### PR DESCRIPTION
The `mach` crate (dependency for macOS) is no longer maintained: [RUSTSEC-2020-0168](https://rustsec.org/advisories/RUSTSEC-2020-0168)/https://github.com/fitzgen/mach/issues/63
[`mach2`](https://github.com/JohnTitor/mach2) is an active fork that works as a drop-in replacement.

All tests pass with `mach2` but I couldn't test all libmacchina features as I don't own a macOS device.