### PR TITLE
Fix Armv7 build

### DIFF
--- a/.github/workflows/libmacchina.yml
+++ b/.github/workflows/libmacchina.yml
@@ -17,6 +17,7 @@ jobs:
           - x86_64-unknown-freebsd
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
 
         include:
           - os: ubuntu-latest
@@ -61,6 +62,12 @@ jobs:
             cross: true
             test: true
             cargo_args: --features "openwrt"
+
+          - os: ubuntu-latest
+            name: Linux ARMv7
+            target: armv7-unknown-linux-gnueabihf
+            cross: true
+            test: true
 
     steps:
       - name: Checkout

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "openwrt"))]
     fn test_which() {
-        assert!(which("python"));
+        assert!(which("sh"));
         assert!(!which("not_a_real_command"));
     }
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -272,6 +272,9 @@ pub(crate) fn disk_space(path: &Path) -> Result<(u64, u64), ReadoutError> {
         let used_byte = disk_size - free;
         let disk_size_byte = disk_size;
 
+        #[cfg(target_pointer_width = "32")]
+        return Ok((used_byte.into(), disk_size_byte.into()));
+        #[cfg(target_pointer_width = "64")]
         return Ok((used_byte, disk_size_byte));
     }
 


### PR DESCRIPTION
The `disk_space()` function needs `.into()` in the return statement when `target_pointer_width` is set to `32` as it returns `u64` values.

I added an armv7 build target to the CI workflow to spot similar problems earlier in the future which required to modify the assertion of `test_which()` as `python` is not available during cross compilation for this target.

[Example of failing armv7 build](https://github.com/Gobidev/pfetch-rs/actions/runs/4958159131/jobs/8870699137)