### PR TITLE
feat: add support for RPM `ndb` databases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,4 +75,3 @@ pkg-config = { version = "0.3.25", optional = true}
 openwrt = []
 version = ["vergen"]
 rpm = ["dep:rpm-pkg-count"]
-default = ["rpm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ dirs = "4.0"
 walkdir = "2.3.2"
 os-release = "0.1"
 regex = "1.6.0"
+rpm-pkg-count = { version = "0.2.0", features = ["runtime"], optional = true }
 
 [target.'cfg(target_os = "netbsd")'.dependencies]
 nix = { version = "0.24.1", default-features = false, features = ["hostname"] }
@@ -73,3 +74,5 @@ pkg-config = { version = "0.3.25", optional = true}
 [features]
 openwrt = []
 version = ["vergen"]
+rpm = ["dep:rpm-pkg-count"]
+default = ["rpm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ dirs = "4.0"
 walkdir = "2.3.2"
 os-release = "0.1"
 regex = "1.6.0"
-rpm-pkg-count = { version = "0.2.0", features = ["runtime"], optional = true }
+rpm-pkg-count = { version = "0.2.0", features = ["runtime"] }
 
 [target.'cfg(target_os = "netbsd")'.dependencies]
 nix = { version = "0.24.1", default-features = false, features = ["hostname"] }
@@ -74,4 +74,3 @@ pkg-config = { version = "0.3.25", optional = true}
 [features]
 openwrt = []
 version = ["vergen"]
-rpm = ["dep:rpm-pkg-count"]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -731,42 +731,35 @@ impl PackageReadout for LinuxPackageReadout {
 }
 
 impl LinuxPackageReadout {
-    fn count_rpm_sqlite() -> Option<usize> {
+    /// Returns the number of installed packages for systems
+    /// that utilize `rpm` as their package manager.
+    fn count_rpm() -> Option<usize> {
         // Return the number of installed packages using sqlite (~1ms)
         // as directly calling rpm or dnf is too expensive (~500ms)
-        let db = "/var/lib/rpm/rpmdb.sqlite";
-        if !Path::new(db).is_file() {
-            return None;
-        }
+        let count_sqlite = 'sqlite: {
+            let db = "/var/lib/rpm/rpmdb.sqlite";
+            if !Path::new(db).is_file() {
+                break 'sqlite None;
+            }
 
-        let connection = sqlite::open(db);
-        if let Ok(con) = connection {
-            let statement = con.prepare("SELECT COUNT(*) FROM Installtid");
-            if let Ok(mut s) = statement {
-                if s.next().is_ok() {
-                    return match s.read::<Option<i64>>(0) {
-                        Ok(Some(count)) => Some(count as usize),
-                        _ => None,
-                    };
+            let connection = sqlite::open(db);
+            if let Ok(con) = connection {
+                let statement = con.prepare("SELECT COUNT(*) FROM Installtid");
+                if let Ok(mut s) = statement {
+                    if s.next().is_ok() {
+                        break 'sqlite match s.read::<Option<i64>>(0) {
+                            Ok(Some(count)) => Some(count as usize),
+                            _ => None,
+                        };
+                    }
                 }
             }
-        }
 
-        None
-    }
+            None
+        };
 
-    /// Returns the number of installed packages for systems
-    /// that utilize `rpm` as their package manager.
-    #[cfg(not(feature = "rpm"))]
-    fn count_rpm() -> Option<usize> {
-        Self::count_rpm_sqlite()
-    }
-
-    /// Returns the number of installed packages for systems
-    /// that utilize `rpm` as their package manager.
-    #[cfg(feature = "rpm")]
-    fn count_rpm() -> Option<usize> {
-        Self::count_rpm_sqlite().or(unsafe { rpm_pkg_count::count() }.map(|count| count as usize))
+        // If counting with sqlite failed, try using librpm instead
+        count_sqlite.or(unsafe { rpm_pkg_count::count() }.map(|count| count as usize))
     }
 
     /// Returns the number of installed packages for systems

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -731,10 +731,7 @@ impl PackageReadout for LinuxPackageReadout {
 }
 
 impl LinuxPackageReadout {
-    /// Returns the number of installed packages for systems
-    /// that utilize `rpm` as their package manager.
-    #[cfg(not(feature = "rpm"))]
-    fn count_rpm() -> Option<usize> {
+    fn count_rpm_sqlite() -> Option<usize> {
         // Return the number of installed packages using sqlite (~1ms)
         // as directly calling rpm or dnf is too expensive (~500ms)
         let db = "/var/lib/rpm/rpmdb.sqlite";
@@ -760,9 +757,16 @@ impl LinuxPackageReadout {
 
     /// Returns the number of installed packages for systems
     /// that utilize `rpm` as their package manager.
+    #[cfg(not(feature = "rpm"))]
+    fn count_rpm() -> Option<usize> {
+        Self::count_rpm_sqlite()
+    }
+
+    /// Returns the number of installed packages for systems
+    /// that utilize `rpm` as their package manager.
     #[cfg(feature = "rpm")]
     fn count_rpm() -> Option<usize> {
-        unsafe { rpm_pkg_count::count() }.map(|count| count as usize)
+        Self::count_rpm_sqlite().or(unsafe { rpm_pkg_count::count() }.map(|count| count as usize))
     }
 
     /// Returns the number of installed packages for systems

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -733,6 +733,7 @@ impl PackageReadout for LinuxPackageReadout {
 impl LinuxPackageReadout {
     /// Returns the number of installed packages for systems
     /// that utilize `rpm` as their package manager.
+    #[cfg(not(feature = "rpm"))]
     fn count_rpm() -> Option<usize> {
         // Return the number of installed packages using sqlite (~1ms)
         // as directly calling rpm or dnf is too expensive (~500ms)
@@ -755,6 +756,13 @@ impl LinuxPackageReadout {
         }
 
         None
+    }
+
+    /// Returns the number of installed packages for systems
+    /// that utilize `rpm` as their package manager.
+    #[cfg(feature = "rpm")]
+    fn count_rpm() -> Option<usize> {
+        unsafe { rpm_pkg_count::count() }.map(|count| count as usize)
     }
 
     /// Returns the number of installed packages for systems

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -759,7 +759,7 @@ impl LinuxPackageReadout {
         };
 
         // If counting with sqlite failed, try using librpm instead
-        count_sqlite.or(unsafe { rpm_pkg_count::count() }.map(|count| count as usize))
+        count_sqlite.or_else(|| unsafe { rpm_pkg_count::count() }.map(|count| count as usize))
     }
 
     /// Returns the number of installed packages for systems


### PR DESCRIPTION
This closes #154.

As mentioned by @CarterLi in https://github.com/Macchina-CLI/libmacchina/issues/154#issuecomment-1509428314, [fastfetch](https://github.com/LinusDierheimer/fastfetch) uses `librpm` to count RPM packages.
There are Rust bindings to librpm ([`librpm-sys`](https://github.com/rpm-software-management/librpm.rs)), however depending on that crate proved to introduce many build complications, and, more importantly, would require `librpm` to be installed on every system that `macchina`, or other binaries depending on `libmacchina`, are run on.

So I instead created a new small crate called [`rpm-pkg-count`](https://github.com/RubixDev/rpm-pkg-count) which directly links to `librpm` and uses fastfetch's method of retrieving the package count. To mitigate the second issue I make use of the [`libloading`](https://crates.io/crates/libloading) crate, which allows me to try and load the `librpm` library at runtime and simply return `None` if it is not found.

The way I currently added `rpm-pkg-count` to `libmacchina` is behind a new feature called `rpm`. With the feature disabled (as it is by default), `libmacchina` continues to use the `sqlite` solution. If you wish, I could also replace the current `sqlite` implementation with the new one. Note, however, that the new method requires `librpm` to be installed on systems for all users that want rpm package count support, even on distros that use the `sqlite` backend, unlike the current manual `sqlite` solution (this may need to be documented somewhere).

Edit: I removed the `rpm` feature again and now libmacchina will always try the existing sqlite method first, as that seems to be faster than using librpm (see https://github.com/Macchina-CLI/libmacchina/pull/159#issuecomment-1546939452). Only if that fails, librpm will be used.