### PR TITLE
Add support for macOS Sonoma in macos_version_to_name function

### DIFF
--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -690,6 +690,7 @@ fn macos_version_to_name(version: &NSOperatingSystemVersion) -> &'static str {
         (11, _) | (10, 16) => "Big Sur",
         (12, _) => "Monterey",
         (13, _) => "Ventura",
+        (14, _) => "Sonoma",
         _ => "Unknown",
     }
 }


### PR DESCRIPTION
display macOS 14 as Sonoma