### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/libmacchina.yml
+++ b/.github/workflows/libmacchina.yml
@@ -3,6 +3,24 @@ on: [push, pull_request]
 name: CI
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- --no-deps -D clippy::all
+
   checks:
     name: ${{ matrix.name }} (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -78,21 +96,11 @@ jobs:
       - name: Bootstrap
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
           targets: ${{ matrix.target }}
 
       - name: Install cross
         run: cargo install cross
         if: ${{ matrix.cross }}
-
-      - name: Formatting
-        run: cargo fmt --all -- --check
-        if: ${{ !matrix.cross }}
-        continue-on-error: false
-
-      - name: Lints
-        run: ${{ env.PROGRAM }} clippy --target=${{ matrix.target }} -- --no-deps -D clippy::all
-        continue-on-error: false
 
       - name: Build
         run: ${{ env.PROGRAM }} build --target=${{ matrix.target }} ${{ matrix.cargo_args }}

--- a/.github/workflows/libmacchina.yml
+++ b/.github/workflows/libmacchina.yml
@@ -6,6 +6,8 @@ jobs:
   checks:
     name: ${{ matrix.name }} (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    env:
+      PROGRAM: ${{ matrix.cross && 'cross' || 'cargo' }}
     strategy:
       fail-fast: false
       matrix:
@@ -71,42 +73,30 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Bootstrap
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        run: cargo install cross
+        if: ${{ matrix.cross }}
 
       - name: Formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
-          use-cross: ${{ matrix.cross }}
+        run: cargo fmt --all -- --check
+        if: ${{ !matrix.cross }}
         continue-on-error: false
 
       - name: Lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --target=${{ matrix.target }} -- --no-deps -D clippy::all
-          use-cross: ${{ matrix.cross }}
+        run: ${{ env.PROGRAM }} clippy --target=${{ matrix.target }} -- --no-deps -D clippy::all
         continue-on-error: false
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.target }} ${{ matrix.cargo_args }}
-          use-cross: ${{ matrix.cross }}
+        run: ${{ env.PROGRAM }} build --target=${{ matrix.target }} ${{ matrix.cargo_args }}
 
-      - name: Test 
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.target }} ${{ matrix.cargo_args }}
-          use-cross: ${{ matrix.cross }}
+      - name: Test
+        run: ${{ env.PROGRAM }} test --target=${{ matrix.target }} ${{ matrix.cargo_args }}
         if: ${{ matrix.test }}

--- a/.github/workflows/libmacchina.yml
+++ b/.github/workflows/libmacchina.yml
@@ -6,6 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint
+    env:
+      RUSTFLAGS: "-Dwarnings"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,7 +21,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- --no-deps -D clippy::all
+        run: cargo clippy --all-targets --all-features
 
   checks:
     name: ${{ matrix.name }} (${{ matrix.target }})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,9 @@ pub struct Readouts {
 #[cfg(feature = "version")]
 pub fn version() -> &'static str {
     if let Some(git_sha) = option_env!("VERGEN_GIT_SHA_SHORT") {
-        return Box::leak(format!("{} ({})", env!("CARGO_PKG_VERSION"), git_sha).into_boxed_str());
+        Box::leak(format!("{} ({})", env!("CARGO_PKG_VERSION"), git_sha).into_boxed_str())
     } else {
-        return env!("CARGO_PKG_VERSION");
+        env!("CARGO_PKG_VERSION")
     }
 }
 

--- a/src/openwrt/mod.rs
+++ b/src/openwrt/mod.rs
@@ -92,11 +92,11 @@ impl GeneralReadout for OpenWrtGeneralReadout {
         let file = fs::File::open("/proc/cpuinfo");
         if let Ok(content) = file {
             let reader = BufReader::new(content);
-            for line in reader.lines().into_iter().map_while(Result::ok) {
+            for line in reader.lines().map_while(Result::ok) {
                 if line.starts_with("machine") {
                     return Ok(line
                         .replace("machine", "")
-                        .replace(":", "")
+                        .replace(':', "")
                         .trim()
                         .to_string());
                 }
@@ -154,11 +154,11 @@ impl GeneralReadout for OpenWrtGeneralReadout {
         let file = fs::File::open("/proc/cpuinfo");
         if let Ok(content) = file {
             let reader = BufReader::new(content);
-            for line in reader.lines().into_iter().map_while(Result::ok) {
+            for line in reader.lines().map_while(Result::ok) {
                 if line.starts_with("cpu model") {
                     return Ok(line
                         .replace("cpu model", "")
-                        .replace(":", "")
+                        .replace(':', "")
                         .trim()
                         .to_string());
                 }
@@ -186,11 +186,11 @@ impl GeneralReadout for OpenWrtGeneralReadout {
             let f_load = 1f64 / (1 << libc::SI_LOAD_SHIFT) as f64;
             let cpu_usage = info.loads[0] as f64 * f_load;
             let cpu_usage_u = (cpu_usage / num_cpus::get() as f64 * 100.0).round() as usize;
-            return Ok(cpu_usage_u as usize);
+            Ok(cpu_usage_u as usize)
         } else {
-            return Err(ReadoutError::Other(String::from(
+            Err(ReadoutError::Other(String::from(
                 "sysinfo struct returned an error.",
-            )));
+            )))
         }
     }
 
@@ -199,11 +199,11 @@ impl GeneralReadout for OpenWrtGeneralReadout {
         let info_ptr: *mut sysinfo = &mut info;
         let ret = unsafe { sysinfo(info_ptr) };
         if ret != -1 {
-            return Ok(info.uptime as usize);
+            Ok(info.uptime as usize)
         } else {
-            return Err(ReadoutError::Other(String::from(
+            Err(ReadoutError::Other(String::from(
                 "sysinfo struct returned an error.",
-            )));
+            )))
         }
     }
 
@@ -232,11 +232,11 @@ impl MemoryReadout for OpenWrtMemoryReadout {
         let info_ptr: *mut sysinfo = &mut info;
         let ret = unsafe { sysinfo(info_ptr) };
         if ret != -1 {
-            return Ok(info.totalram as u64 * info.mem_unit as u64 / 1024);
+            Ok(info.totalram as u64 * info.mem_unit as u64 / 1024)
         } else {
-            return Err(ReadoutError::Other(String::from(
+            Err(ReadoutError::Other(String::from(
                 "sysinfo struct returned an error.",
-            )));
+            )))
         }
     }
 
@@ -245,11 +245,11 @@ impl MemoryReadout for OpenWrtMemoryReadout {
         let info_ptr: *mut sysinfo = &mut info;
         let ret = unsafe { sysinfo(info_ptr) };
         if ret != -1 {
-            return Ok(info.freeram as u64 * info.mem_unit as u64 / 1024);
+            Ok(info.freeram as u64 * info.mem_unit as u64 / 1024)
         } else {
-            return Err(ReadoutError::Other(String::from(
+            Err(ReadoutError::Other(String::from(
                 "sysinfo struct returned an error.",
-            )));
+            )))
         }
     }
 
@@ -258,11 +258,11 @@ impl MemoryReadout for OpenWrtMemoryReadout {
         let info_ptr: *mut sysinfo = &mut info;
         let ret = unsafe { sysinfo(info_ptr) };
         if ret != -1 {
-            return Ok(info.bufferram as u64 * info.mem_unit as u64 / 1024);
+            Ok(info.bufferram as u64 * info.mem_unit as u64 / 1024)
         } else {
-            return Err(ReadoutError::Other(format!(
-                "Failed to get system statistics"
-            )));
+            Err(ReadoutError::Other(String::from(
+                "Failed to get system statistics",
+            )))
         }
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,17 +22,17 @@ pub enum ReadoutError {
     Warning(String),
 }
 
-impl ToString for ReadoutError {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for ReadoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReadoutError::MetricNotAvailable => {
-                String::from("Metric is not available on this system.")
+                write!(f, "Metric is not available on this system.")
             }
             ReadoutError::NotImplemented => {
-                String::from("This metric is not available on this platform or is not yet implemented by libmacchina.")
+                write!(f, "This metric is not available on this platform or is not yet implemented by libmacchina.")
             }
-            ReadoutError::Other(s) => s.clone(),
-            ReadoutError::Warning(s) => s.clone(),
+            ReadoutError::Other(s) => write!(f, "{}", s),
+            ReadoutError::Warning(s) => write!(f, "{}", s),
         }
     }
 }
@@ -657,26 +657,26 @@ pub enum PackageManager {
     Scoop,
 }
 
-impl ToString for PackageManager {
-    fn to_string(&self) -> String {
-        String::from(match self {
-            PackageManager::Homebrew => "Homebrew",
-            PackageManager::MacPorts => "MacPorts",
-            PackageManager::Pacman => "pacman",
-            PackageManager::Portage => "portage",
-            PackageManager::Dpkg => "dpkg",
-            PackageManager::Opkg => "opkg",
-            PackageManager::Xbps => "xbps",
-            PackageManager::Pkgsrc => "pkgsrc",
-            PackageManager::Apk => "apk",
-            PackageManager::Eopkg => "eopkg",
-            PackageManager::Rpm => "rpm",
-            PackageManager::Cargo => "cargo",
-            PackageManager::Flatpak => "flatpak",
-            PackageManager::Snap => "snap",
-            PackageManager::Android => "Android",
-            PackageManager::Pkg => "pkg",
-            PackageManager::Scoop => "Scoop",
-        })
+impl std::fmt::Display for PackageManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PackageManager::Homebrew => write!(f, "Homebrew"),
+            PackageManager::MacPorts => write!(f, "MacPorts"),
+            PackageManager::Pacman => write!(f, "pacman"),
+            PackageManager::Portage => write!(f, "portage"),
+            PackageManager::Dpkg => write!(f, "dpkg"),
+            PackageManager::Opkg => write!(f, "opkg"),
+            PackageManager::Xbps => write!(f, "xbps"),
+            PackageManager::Pkgsrc => write!(f, "pkgsrc"),
+            PackageManager::Apk => write!(f, "apk"),
+            PackageManager::Eopkg => write!(f, "eopkg"),
+            PackageManager::Rpm => write!(f, "rpm"),
+            PackageManager::Cargo => write!(f, "cargo"),
+            PackageManager::Flatpak => write!(f, "flatpak"),
+            PackageManager::Snap => write!(f, "snap"),
+            PackageManager::Android => write!(f, "Android"),
+            PackageManager::Pkg => write!(f, "pkg"),
+            PackageManager::Scoop => write!(f, "Scoop"),
+        }
     }
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -455,12 +455,10 @@ impl NetworkReadout for WindowsNetworkReadout {
 
     fn logical_address(&self, interface: Option<&str>) -> Result<String, ReadoutError> {
         match interface {
-            Some(it) => {
+            Some(interface) => {
                 if let Ok(addresses) = local_ip_address::list_afinet_netifas() {
-                    for (name, ip) in addresses.iter() {
-                        if let Some(name) = interface {
-                            return Ok(ip.to_string());
-                        }
+                    if let Some((_, ip)) = addresses.iter().find(|(name, _)| name == interface) {
+                        return Ok(ip.to_string());
                     }
                 }
             }


### PR DESCRIPTION
These are the same changes already applied to `macchina`: Macchina-CLI/macchina#311 & Macchina-CLI/macchina#313
- Replacement of `actions-rs` with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) and explicit calls to the respective `cargo`/`cross` commands.
- Extracting the `cargo fmt` and `cargo clippy` steps into their own jobs.
- Fail `clippy` on warnings (required some minor code changes).