### PR TITLE
Faster package count on Alpine Linux

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -855,6 +855,12 @@ impl LinuxPackageReadout {
     /// Returns the number of installed packages for systems
     /// that utilize `apk` as their package manager.
     fn count_apk() -> Option<usize> {
+        // faster method for alpine: count empty lines in /lib/apk/db/installed
+        if let Ok(content) = fs::read_to_string(Path::new("/lib/apk/db/installed")) {
+            return Some(content.lines().filter(|l| l.is_empty()).count());
+        }
+
+        // fallback to command invocation
         if !extra::which("apk") {
             return None;
         }


### PR DESCRIPTION
On Alpine Linux, packages can be counted by counting the amount of empty lines in `/lib/apk/db/installed`.
On my test VM, this takes about 5ms compared to 80ms with the previous method with 82 packages installed.

I left the previous counting method as fallback, in case there are systems that use `apk` where the new one does not work.

Related to https://github.com/Gobidev/pfetch-rs/issues/48