### PR TITLE
add macos 15 version name

### DIFF
--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -691,6 +691,7 @@ fn macos_version_to_name(version: &NSOperatingSystemVersion) -> &'static str {
         (12, _) => "Monterey",
         (13, _) => "Ventura",
         (14, _) => "Sonoma",
+        (15, _) => "Sequoia",
         _ => "Unknown",
     }
 }


### PR DESCRIPTION
https://www.apple.com/newsroom/2024/06/macos-sequoia-takes-productivity-and-intelligence-on-mac-to-new-heights/