### PR TITLE
Add support for the Nix package manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ windows = { version = "0.39.0", features = [
 if-addrs = "0.10.2"
 
 [target.'cfg(any(target_os="freebsd", target_os = "linux"))'.dependencies]
-sqlite = "0.31.1"
+sqlite = "0.36.0"
 
 [target.'cfg(any(target_os="freebsd", target_os = "netbsd"))'.dependencies]
 x11rb = "0.12.0"

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -548,28 +548,29 @@ impl GeneralReadout for LinuxGeneralReadout {
     }
 
     fn gpus(&self) -> Result<Vec<String>, ReadoutError> {
-        match Database::read() {
-            Ok(db) => {
-                let devices = get_pci_devices()?;
-                let mut gpus = vec![];
+        let db = match Database::read() {
+            Ok(db) => db,
+            _ => return Err(ReadoutError::MetricNotAvailable),
+        };
 
-                for device in devices {
-                    if !device.is_gpu(&db) {
-                        continue;
-                    };
 
-                    if let Some(sub_device_name) = device.get_device_name(&db) {
-                        gpus.push(sub_device_name);
-                    };
-                }
+        let devices = get_pci_devices()?;
+        let mut gpus = vec![];
 
-                if gpus.is_empty() {
-                    Err(ReadoutError::MetricNotAvailable)
-                } else {
-                    Ok(gpus)
-                }
-            },
-            _ => Err(ReadoutError::MetricNotAvailable),
+        for device in devices {
+            if !device.is_gpu(&db) {
+                continue;
+            };
+
+            if let Some(sub_device_name) = device.get_device_name(&db) {
+                gpus.push(sub_device_name);
+            };
+        }
+
+        if gpus.is_empty() {
+            Err(ReadoutError::MetricNotAvailable)
+        } else {
+            Ok(gpus)
         }
     }
 }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -942,8 +942,8 @@ impl LinuxPackageReadout {
     /// Returns the number of installed packages for systems
     /// that utilize `nix` as their package manager.
     fn count_nix() -> Option<usize> {
-        // Return the number of installed packages using sqlite (~10ms)
-        // as directly calling nix is a bit more expensive (~40ms)
+        // Return the number of installed packages using nix's database (~10ms)
+        // as directly calling to nix is a bit more expensive (~40ms)
         return 'sqlite: {
             let db = "/nix/var/nix/db/db.sqlite";
             if !Path::new(db).is_file() {
@@ -957,7 +957,7 @@ impl LinuxPackageReadout {
             );
 
             if let Ok(con) = connection {
-                // nix path-info --all --sigs | fgrep ultimate | wc -l 
+                // Equivelent to `nix path-info --all --sigs | grep ultimate | wc -l`
                 let statement = con.prepare("SELECT COUNT(path) FROM ValidPaths WHERE ultimate=1");
 
                 if let Ok(mut s) = statement {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -942,8 +942,6 @@ impl LinuxPackageReadout {
     /// Returns the number of installed packages for systems
     /// that utilize `nix` as their package manager.
     fn count_nix() -> Option<usize> {
-        // Return the number of installed packages using nix's database (~10ms)
-        // as directly calling to nix is a bit more expensive (~40ms)
         return 'sqlite: {
             let db = "/nix/var/nix/db/db.sqlite";
             if !Path::new(db).is_file() {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -952,7 +952,7 @@ impl LinuxPackageReadout {
             let connection = sqlite::Connection::open_with_flags(
                 // The nix store is immutable, so we need to inform sqlite about it
                 "file:".to_owned() + db + "?immutable=1", 
-                sqlite::OpenFlags::new().with_read_only().with_uri()
+                sqlite::OpenFlags::new().with_read_only().with_uri(),
             );
 
             if let Ok(con) = connection {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -956,7 +956,8 @@ impl LinuxPackageReadout {
 
             if let Ok(con) = connection {
                 // Equivelent to `nix path-info --all --sigs | grep ultimate | wc -l`
-                let statement = con.prepare("SELECT COUNT(path) FROM ValidPaths WHERE sigs IS NOT NULL");
+                let statement =
+                    con.prepare("SELECT COUNT(path) FROM ValidPaths WHERE sigs IS NOT NULL");
 
                 if let Ok(mut s) = statement {
                     if s.next().is_ok() {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -956,7 +956,7 @@ impl LinuxPackageReadout {
 
             if let Ok(con) = connection {
                 // Equivelent to `nix path-info --all --sigs | grep ultimate | wc -l`
-                let statement = con.prepare("SELECT COUNT(path) FROM ValidPaths WHERE ultimate=1");
+                let statement = con.prepare("SELECT COUNT(path) FROM ValidPaths WHERE sigs IS NOT NULL");
 
                 if let Ok(mut s) = statement {
                     if s.next().is_ok() {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -955,7 +955,6 @@ impl LinuxPackageReadout {
             );
 
             if let Ok(con) = connection {
-                // Equivelent to `nix path-info --all --sigs | grep ultimate | wc -l`
                 let statement =
                     con.prepare("SELECT COUNT(path) FROM ValidPaths WHERE sigs IS NOT NULL");
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -553,7 +553,6 @@ impl GeneralReadout for LinuxGeneralReadout {
             _ => return Err(ReadoutError::MetricNotAvailable),
         };
 
-
         let devices = get_pci_devices()?;
         let mut gpus = vec![];
 
@@ -951,7 +950,7 @@ impl LinuxPackageReadout {
 
             let connection = sqlite::Connection::open_with_flags(
                 // The nix store is immutable, so we need to inform sqlite about it
-                "file:".to_owned() + db + "?immutable=1", 
+                "file:".to_owned() + db + "?immutable=1",
                 sqlite::OpenFlags::new().with_read_only().with_uri(),
             );
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -655,6 +655,8 @@ pub enum PackageManager {
     Android,
     Pkg,
     Scoop,
+    NixSystem,
+    NixUser,
 }
 
 impl std::fmt::Display for PackageManager {
@@ -677,6 +679,8 @@ impl std::fmt::Display for PackageManager {
             PackageManager::Android => write!(f, "Android"),
             PackageManager::Pkg => write!(f, "pkg"),
             PackageManager::Scoop => write!(f, "Scoop"),
+            PackageManager::NixSystem => write!(f, "nix-system"),
+            PackageManager::NixUser => write!(f, "nix-user"),
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -655,8 +655,7 @@ pub enum PackageManager {
     Android,
     Pkg,
     Scoop,
-    NixSystem,
-    NixUser,
+    Nix,
 }
 
 impl std::fmt::Display for PackageManager {
@@ -679,8 +678,7 @@ impl std::fmt::Display for PackageManager {
             PackageManager::Android => write!(f, "Android"),
             PackageManager::Pkg => write!(f, "pkg"),
             PackageManager::Scoop => write!(f, "Scoop"),
-            PackageManager::NixSystem => write!(f, "nix-system"),
-            PackageManager::NixUser => write!(f, "nix-user"),
+            PackageManager::Nix => write!(f, "nix"),
         }
     }
 }


### PR DESCRIPTION
Similar to https://github.com/Macchina-CLI/libmacchina/pull/150 except updated to the latest version of libmacchina. (closes https://github.com/Macchina-CLI/libmacchina/issues/120)
Unlike that commit which attempts to estimate the total amount of nix pkgs by counting the files in `/nix/store`, this uses nix's sqlite database (`/nix/var/nix/db/db.sqlite`).\
The sqlite library has also been updated (0.31.1 -> 0.36.0) due to it having the ability to read the path as a uri (so that I can tell sqlite that the database is immutable).

This queries the database using `SELECT COUNT(path) FROM ValidPaths WHERE ultimate=1` (which is equivalent to `nix path-info --all --sigs | grep ultimate | wc -l`) which gives a time of around 10ms, while the equivalent nix command gives around 40ms.

This lookup is grabbing a slightly different metric which gives 739 on my system (nix store giving 1306). So I think nix store is including extra things that don't count as packages (as the `/nix/store` folder stores everything from fetches, sources, man pages, binaries, etc).

(all packages built with `cargo build --release`, and tested with `hyperfine -w 4 -m 500 -N`)
| Type | Speed |
| --- | --- |
| Original Macchina | 5.9 ms ± 0.2 ms |
| SQLite Lookup | 14.2 ms ± 1.7 ms |
