### PR TITLE
Removed panic if local gpu db is not able to be read

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -550,7 +550,7 @@ impl GeneralReadout for LinuxGeneralReadout {
     fn gpus(&self) -> Result<Vec<String>, ReadoutError> {
         let db = match Database::read() {
             Ok(db) => db,
-            _ => panic!("Could not read pci.ids file"),
+            _ => return Err(ReadoutError::MetricNotAvailable),
         };
 
         let devices = get_pci_devices()?;


### PR DESCRIPTION
Some minimal distros don't come with the pciutils package, or have the pci.id file in a different location that isn't picked up by pciid-parser.\
This is just a simple fix to throw an error, rather than a panic.