### PR TITLE
Fix displayed name for GNOME Terminal and Black Box

### DIFF
--- a/src/extra.rs
+++ b/src/extra.rs
@@ -92,6 +92,14 @@ pub fn common_shells() -> [&'static str; 10] {
     ]
 }
 
+pub fn terminal_replacements(command: &str) -> &str {
+    match command {
+        "gnome-terminal-" => "gnome-terminal",
+        "blackbox-termin" => "blackbox",
+        _ => command,
+    }
+}
+
 #[cfg(test)]
 #[cfg(not(target_os = "netbsd"))]
 mod tests {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -6,6 +6,7 @@ use self::pci_devices::get_pci_devices;
 use crate::extra;
 use crate::extra::get_entries;
 use crate::extra::path_extension;
+use crate::extra::terminal_replacements;
 use crate::shared;
 use crate::traits::*;
 use itertools::Itertools;
@@ -417,10 +418,11 @@ impl GeneralReadout for LinuxGeneralReadout {
             // The below loop will traverse /proc to find the
             // terminal inside of which the user is operating
             if let Ok(mut terminal_name) = fs::read_to_string(path) {
+                terminal_name = terminal_name.trim().to_string();
                 // Any command_name we find that matches
                 // one of the elements within this table
                 // is effectively ignored
-                while extra::common_shells().contains(&terminal_name.replace('\n', "").as_str()) {
+                while extra::common_shells().contains(&terminal_name.as_str()) {
                     let ppid = get_parent(terminal_pid);
                     terminal_pid = ppid;
 
@@ -438,6 +440,7 @@ impl GeneralReadout for LinuxGeneralReadout {
         }
 
         let terminal = terminal_name();
+        let terminal = terminal_replacements(&terminal);
 
         if terminal.is_empty() {
             return Err(ReadoutError::Other(
@@ -445,7 +448,7 @@ impl GeneralReadout for LinuxGeneralReadout {
             ));
         }
 
-        Ok(terminal)
+        Ok(terminal.to_string())
     }
 
     fn shell(&self, format: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError> {


### PR DESCRIPTION
libmacchina uses /proc/<pid>/comm, which is limited to 15 chars and it's not guaranteed to hold a user friendly name.

For example GNOME Terminal is actually /usr/libexec/gnome-terminal-server and its `comm` is `gnome-terminal-`.

Add a replacement function that returns user friendly names and that can be expanded with more.