### PR TITLE
feat: implement swap usage for linux

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -358,6 +358,18 @@ impl MemoryReadout for AndroidMemoryReadout {
 
         Ok(total - free - cached - reclaimable - buffers)
     }
+
+    fn swap_total(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_free(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_used(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
 }
 
 impl ProductReadout for AndroidProductReadout {

--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -349,6 +349,18 @@ impl MemoryReadout for FreeBSDMemoryReadout {
 
         Ok(total - free)
     }
+
+    fn swap_total(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_free(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_used(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
 }
 
 impl ProductReadout for FreeBSDProductReadout {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -641,6 +641,45 @@ impl MemoryReadout for LinuxMemoryReadout {
             available => Ok(total - available),
         }
     }
+
+    fn swap_total(&self) -> Result<u64, ReadoutError> {
+        let mut info = self.sysinfo;
+        let info_ptr: *mut sysinfo = &mut info;
+        let ret = unsafe { sysinfo(info_ptr) };
+        if ret != -1 {
+            Ok(info.totalswap as u64 * info.mem_unit as u64 / 1024)
+        } else {
+            Err(ReadoutError::Other(
+                "Something went wrong during the initialization of the sysinfo struct.".to_string(),
+            ))
+        }
+    }
+
+    fn swap_free(&self) -> Result<u64, ReadoutError> {
+        let mut info = self.sysinfo;
+        let info_ptr: *mut sysinfo = &mut info;
+        let ret = unsafe { sysinfo(info_ptr) };
+        if ret != -1 {
+            Ok(info.freeswap as u64 * info.mem_unit as u64 / 1024)
+        } else {
+            Err(ReadoutError::Other(
+                "Something went wrong during the initialization of the sysinfo struct.".to_string(),
+            ))
+        }
+    }
+
+    fn swap_used(&self) -> Result<u64, ReadoutError> {
+        let mut info = self.sysinfo;
+        let info_ptr: *mut sysinfo = &mut info;
+        let ret = unsafe { sysinfo(info_ptr) };
+        if ret != -1 {
+            Ok((info.totalswap as u64 - info.freeswap as u64) * info.mem_unit as u64 / 1024)
+        } else {
+            Err(ReadoutError::Other(
+                "Something went wrong during the initialization of the sysinfo struct.".to_string(),
+            ))
+        }
+    }
 }
 
 impl ProductReadout for LinuxProductReadout {

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -488,6 +488,18 @@ impl MemoryReadout for MacOSMemoryReadout {
 
         Ok(used)
     }
+
+    fn swap_total(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_free(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_used(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
 }
 
 impl MacOSMemoryReadout {

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -369,6 +369,18 @@ impl MemoryReadout for NetBSDMemoryReadout {
 
         Ok(total - free)
     }
+
+    fn swap_total(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_free(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_used(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
 }
 
 impl ProductReadout for NetBSDProductReadout {

--- a/src/openwrt/mod.rs
+++ b/src/openwrt/mod.rs
@@ -287,6 +287,18 @@ impl MemoryReadout for OpenWrtMemoryReadout {
 
         Ok(total - free - cached - buffers)
     }
+
+    fn swap_total(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_free(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_used(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
 }
 
 impl PackageReadout for OpenWrtPackageReadout {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -222,6 +222,15 @@ pub trait MemoryReadout {
 
     /// This function should return the amount of currently used memory in kilobytes.
     fn used(&self) -> Result<u64, ReadoutError>;
+
+    /// This function should return of the total available swap in kilobytes.
+    fn swap_total(&self) -> Result<u64, ReadoutError>;
+
+    /// This function should return the amount of the free available swap in kilobytes.
+    fn swap_free(&self) -> Result<u64, ReadoutError>;
+
+    /// This function should return the amount of currently used swap in kilobytes.
+    fn swap_used(&self) -> Result<u64, ReadoutError>;
 }
 
 /**

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -130,6 +130,18 @@ impl MemoryReadout for WindowsMemoryReadout {
         let memory_status = WindowsMemoryReadout::get_memory_status()?;
         Ok((memory_status.ullTotalPhys - memory_status.ullAvailPhys) / 1024u64)
     }
+
+    fn swap_total(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_free(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
+
+    fn swap_used(&self) -> Result<u64, ReadoutError> {
+        return Err(ReadoutError::NotImplemented);
+    }
 }
 
 impl WindowsMemoryReadout {


### PR DESCRIPTION
First of all, thanks for that amazing library, the performance and resource usage are really impressive compared to other similar libraries I've tried.

This PR implements swap for Linux, based on the already existing implementation for RAM that's using the `sysinfo` syscall.

It's probably possible to read that information from `/proc/meminfo` on Android, BSD and OpenWRT, but since I'm not having access to a device running BSD (and not enough motivation to test it on Android and OpenWRT because it's already too late in the day), this will be left unimplemented for now. I'd probably implement support for the mentioned operation systems as well if you're generally okay with this change.

Cheers.