### PR TITLE
Add support for winget and chocolatey package counts on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ windows = { version = "0.39.0", features = [
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 if-addrs = "0.10.2"
 
-[target.'cfg(any(target_os="freebsd", target_os = "linux"))'.dependencies]
+[target.'cfg(any(target_os="freebsd", target_os = "linux", target_os = "windows"))'.dependencies]
 sqlite = "0.36.0"
 
 [target.'cfg(any(target_os="freebsd", target_os = "netbsd"))'.dependencies]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -668,6 +668,7 @@ pub enum PackageManager {
     Pkg,
     Scoop,
     Nix,
+    Winget,
 }
 
 impl std::fmt::Display for PackageManager {
@@ -691,6 +692,7 @@ impl std::fmt::Display for PackageManager {
             PackageManager::Pkg => write!(f, "pkg"),
             PackageManager::Scoop => write!(f, "Scoop"),
             PackageManager::Nix => write!(f, "nix"),
+            PackageManager::Winget => write!(f, "winget"),
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -669,6 +669,7 @@ pub enum PackageManager {
     Scoop,
     Nix,
     Winget,
+    Chocolatey,
 }
 
 impl std::fmt::Display for PackageManager {
@@ -693,6 +694,7 @@ impl std::fmt::Display for PackageManager {
             PackageManager::Scoop => write!(f, "Scoop"),
             PackageManager::Nix => write!(f, "nix"),
             PackageManager::Winget => write!(f, "winget"),
+            PackageManager::Chocolatey => write!(f, "choco"),
         }
     }
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,6 +1,7 @@
 use crate::traits::*;
 use std::collections::HashMap;
 use std::env;
+use std::fs::read_dir;
 use std::path::{Path, PathBuf};
 use winreg::enums::*;
 use winreg::RegKey;
@@ -425,6 +426,9 @@ impl PackageReadout for WindowsPackageReadout {
         if let Some(c) = WindowsPackageReadout::count_winget() {
             packages.push((PackageManager::Winget, c));
         }
+        if let Some(c) = WindowsPackageReadout::count_chocolatey() {
+            packages.push((PackageManager::Chocolatey, c));
+        }
         packages
     }
 }
@@ -462,6 +466,16 @@ impl WindowsPackageReadout {
                         };
                     }
                 }
+            }
+        }
+        None
+    }
+
+    fn count_chocolatey() -> Option<usize> {
+        let chocolatey_dir = Path::new("C:\\ProgramData\\chocolatey\\lib");
+        if chocolatey_dir.is_dir() {
+            if let Ok(read_dir) = read_dir(chocolatey_dir) {
+                return Some(read_dir.count());
             }
         }
         None


### PR DESCRIPTION
closes #181 

Chocolatey package count is very straight forward, as it just counts the directories under `C:\ProgramData\chocolatey\lib`, which is consistent with `chocolatey list`.

For winget, I made use of an sqlite3 database under `C:\Users\Username\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\Microsoft.Winget.Source_8wekyb3d8bbwe\installed.db`, that contains a table `ids` with entries for each package that is explicitly installed with `winget`.

`winget list` lists a bunch more packages as installed by `winget`, e.g. `Microsoft OneDrive` and `Cortana`, but since those were not installed by the user using winget and those packages that were, are included, I think this is good as is.
Nevertheless, feedback by @Un1q32 or @Kodehawa from https://github.com/Gobidev/pfetch-rs/issues/69 for this is welcome.