### PR TITLE
Fix lint warnings

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -993,7 +993,7 @@ impl LinuxPackageReadout {
     /// Returns the number of installed packages for systems
     /// that utilize `nix` as their package manager.
     fn count_nix() -> Option<usize> {
-        return 'sqlite: {
+        'sqlite: {
             let db = "/nix/var/nix/db/db.sqlite";
             if !Path::new(db).is_file() {
                 break 'sqlite None;
@@ -1020,6 +1020,6 @@ impl LinuxPackageReadout {
             }
 
             None
-        };
+        }
     }
 }

--- a/src/linux/pci_devices.rs
+++ b/src/linux/pci_devices.rs
@@ -68,13 +68,9 @@ impl PciDevice {
         let device_value = self.read_value(PciDeviceReadableValues::Device);
         let sub_device_value = self.read_value(PciDeviceReadableValues::SubDevice);
 
-        let Some(vendor) = db.vendors.get(&vendor_value) else {
-            return None;
-        };
+        let vendor = db.vendors.get(&vendor_value)?;
+        let device = vendor.devices.get(&device_value)?;
 
-        let Some(device) = vendor.devices.get(&device_value) else {
-            return None;
-        };
         // To return device name if no valid subdevice name is found
         let device_name = device.name.to_owned();
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -564,7 +564,6 @@ pub trait GeneralReadout {
 
     _e.g._ /bin/bash, /bin/zsh, etc.
     */
-
     fn shell(&self, _shorthand: ShellFormat, kind: ShellKind) -> Result<String, ReadoutError>;
 
     /// This function should return the model name of the CPU \

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -132,15 +132,15 @@ impl MemoryReadout for WindowsMemoryReadout {
     }
 
     fn swap_total(&self) -> Result<u64, ReadoutError> {
-        return Err(ReadoutError::NotImplemented);
+        Err(ReadoutError::NotImplemented)
     }
 
     fn swap_free(&self) -> Result<u64, ReadoutError> {
-        return Err(ReadoutError::NotImplemented);
+        Err(ReadoutError::NotImplemented)
     }
 
     fn swap_used(&self) -> Result<u64, ReadoutError> {
-        return Err(ReadoutError::NotImplemented);
+        Err(ReadoutError::NotImplemented)
     }
 }
 
@@ -350,7 +350,7 @@ impl GeneralReadout for WindowsGeneralReadout {
         ))
     }
 
-    fn disk_space(&self, path: &Path) -> Result<(u64, u64), ReadoutError> {
+    fn disk_space(&self, _path: &Path) -> Result<(u64, u64), ReadoutError> {
         Err(ReadoutError::NotImplemented)
     }
 

--- a/src/winman.rs
+++ b/src/winman.rs
@@ -108,7 +108,7 @@ pub fn detect_xorg_window_manager() -> Result<String, ReadoutError> {
     }
 
     if extra::which("wmctrl") {
-        let wmctrl = Command::new("wmctrl")
+        let mut wmctrl = Command::new("wmctrl")
             .arg("-m")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -117,6 +117,7 @@ pub fn detect_xorg_window_manager() -> Result<String, ReadoutError> {
 
         let wmctrl_out = wmctrl
             .stdout
+            .take()
             .expect("ERROR: failed to open \"wmctrl\" stdout");
 
         let head = Command::new("head")
@@ -129,6 +130,10 @@ pub fn detect_xorg_window_manager() -> Result<String, ReadoutError> {
         let output = head
             .wait_with_output()
             .expect("ERROR: failed to wait for \"head\" process to exit");
+
+        wmctrl
+            .wait()
+            .expect("ERROR: failed to wait for \"wmctrl\" process to exit");
 
         let window_manager = String::from_utf8(output.stdout)
             .expect("ERROR: \"wmctrl -m | head -n1\" process stdout was not valid UTF-8");


### PR DESCRIPTION
Fix clippy lint warnings for linux and windows targets.

Note: I could not easily verify that the `wmctrl` function still works with the additional `wait()` but I don't see any reason why it wouldn't.